### PR TITLE
Fix issue 58

### DIFF
--- a/docs/tern.shacl.ttl
+++ b/docs/tern.shacl.ttl
@@ -159,6 +159,51 @@ tern-shacl:Distribution
     sh:targetClass <https://w3id.org/tern/ontologies/tern/Distribution> ;
 .
 
+tern-shacl:Duration
+    a sh:NodeShape ;
+    sh:property
+        [
+            a sh:PropertyShape ;
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "numeric duration" ;
+            sh:path time:numericDuration
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "unit type" ;
+            sh:nodeKind sh:IRI ;
+            sh:or (
+                    [
+                        sh:hasValue time:unitDay
+                    ]
+                    [
+                        sh:hasValue time:unitHour
+                    ]
+                    [
+                        sh:hasValue time:unitMinute
+                    ]
+                    [
+                        sh:hasValue time:unitMonth
+                    ]
+                    [
+                        sh:hasValue time:unitSecond
+                    ]
+                    [
+                        sh:hasValue time:unitWeek
+                    ]
+                    [
+                        sh:hasValue time:unitYear
+                    ]
+                ) ;
+            sh:path time:unitType
+        ] ;
+    sh:targetClass time:Duration ;
+.
+
 tern-shacl:FeatureOfInterest
     a sh:NodeShape ;
     sh:property
@@ -272,20 +317,41 @@ tern-shacl:Instant
     a sh:NodeShape ;
     sh:property [
             a sh:PropertyShape ;
-            sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:name "in XSDDate time stamp" ;
             sh:or (
                     [
-                        sh:datatype xsd:dateTimeStamp
+                        sh:datatype xsd:date ;
+                        sh:name "date" ;
+                        sh:path time:inXSDDate
                     ]
                     [
-                        sh:datatype xsd:dateTime
+                        sh:datatype xsd:dateTimeStamp ;
+                        sh:name "date timestamp" ;
+                        sh:path time:inXSDDateTimeStamp
                     ]
-                ) ;
-            sh:path time:inXSDDateTimeStamp
+                    [
+                        sh:datatype xsd:gYear ;
+                        sh:name "year" ;
+                        sh:path time:inXSDYear
+                    ]
+                    [
+                        sh:datatype xsd:gYearMonth ;
+                        sh:name "year month" ;
+                        sh:path time:inXSDYearMonth
+                    ]
+                    [
+                        sh:class time:TimePosition ;
+                        sh:name "in time position" ;
+                        sh:path time:inTimePosition
+                    ]
+                    [
+                        sh:class time:GeneralDateTimeDescription ;
+                        sh:name "in date time" ;
+                        sh:path time:inDateTime
+                    ]
+                )
         ] ;
-    sh:targetClass <https://w3id.org/tern/ontologies/tern/Instant> ;
+    sh:targetClass time:Instant ;
 .
 
 tern-shacl:Integer
@@ -321,6 +387,35 @@ tern-shacl:Integer
             sh:path <https://w3id.org/tern/ontologies/tern/unit>
         ] ;
     sh:targetClass <https://w3id.org/tern/ontologies/tern/Integer> ;
+.
+
+tern-shacl:Interval
+    a sh:NodeShape ;
+    sh:property
+        [
+            a sh:PropertyShape ;
+            sh:class time:Instant ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path time:hasBeginning
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:class time:Duration ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path time:hasDuration
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:class time:Instant ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path time:hasEnd
+        ] ;
+    sh:targetClass time:Interval ;
 .
 
 tern-shacl:ManagedFeature

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -468,12 +468,6 @@ tern:IRI
         tern:Value ;
 .
 
-tern:Instant
-    a owl:Class ;
-    rdfs:label "Instant" ;
-    rdfs:subClassOf time:Instant ;
-.
-
 tern:ManagedFeature
     a owl:Class ;
     rdfs:label "Feature which is managed for TERN purposes" ;

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -738,6 +738,13 @@ tern:observationType
     skos:example "human observation, machine observation." ;
 .
 
+tern:polygon
+    a rdf:Property ;
+    rdfs:label "polygon" ;
+    rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ;
+    skos:definition "The polygon of the subject." ;
+.
+
 tern:sampleStorageLocation
     a rdf:Property ;
     rdfs:label "sample storage location" ;
@@ -1214,13 +1221,6 @@ tern:methodType
     skos:definition "A particular method type used to conduct some survey." ;
 .
 
-tern:polygon
-    a rdf:Property ;
-    rdfs:label "polygon" ;
-    rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ;
-    skos:definition "The polygon of the subject." ;
-.
-
 tern:scope
     a owl:DatatypeProperty ;
     rdfs:label "scope" ;
@@ -1608,7 +1608,13 @@ tern:Observation
         ] ,
         [
             a owl:Restriction ;
-            owl:onClass time:Instant ;
+            owl:onClass [
+                    a owl:Class ;
+                    owl:unionOf (
+                            time:Instant
+                            time:Interval
+                        )
+                ] ;
             owl:onProperty sosa:phenomenonTime ;
             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
         ] ,


### PR DESCRIPTION
Fixes https://github.com/ternaustralia/ontology_tern/issues/58 https://github.com/ternaustralia/ontology_tern/issues/57

We no longer create specialised classes from TIME Ont. There is no requirement for specialisation of these classes. 

The SHACL NodeShapes target `time:Instant`, `time:Interval` and `time:Duration`.

`tern-shacl:Instant` NodeShape requires `time:Instant` at least 1 property out of:

- `time:inXSDDate`
- `time:inXSDDateTimeStamp`
- `time:inXSDYear`
- `time:inXSDYearMonth`
- `time:inTimePosition`
- `time:inDateTime`

`tern-shacl:Interval` NodeShape requires 1..1 of `time:hasBeginning`, 1..1 of `time:hasEnd` and 0..1 of `time:hasDuration`.

`tern-shacl:Duration` NodeShape requires 1..1 of `time:numericDuration` and 1..1 `time:unitType`. 