### PR TITLE
fix time:Instant shape

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,15 @@ on:
   # See https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#creating-a-reusable-workflow
   workflow_call:
 
-  push:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
     branches:
+      # Run on all branches.
       - "**"
-      # Tests run on all branches merged into master. No need to run tests on master again.
+      # But not on master.
       - "!master"
 
 jobs:

--- a/docs/tern.shacl.ttl
+++ b/docs/tern.shacl.ttl
@@ -146,85 +146,107 @@ tern-shacl:IRI
 
 tern-shacl:Instant
     a sh:NodeShape ;
-    rdfs:comment "One or more of (time:inXSDDate, time:inXSDDateTimeStamp, time:inXSDgYear, time:inXSDgYearMonth, time:inTimePosition, and time:inDateTime) must be present. Only one value for each property is allowed." ;
+    sh:message "One or more of (time:inXSDDate, time:inXSDDateTimeStamp, time:inXSDgYear, time:inXSDgYearMonth, time:inTimePosition, and time:inDateTime) must be present. Only one value for each property is allowed." ;
+    sh:property [
+        sh:datatype xsd:dateTime ;
+        sh:path time:inDateTime ;
+    ] ;
+    sh:property [
+        sh:class time:TimePosition ;
+        sh:path time:inTimePosition ;
+    ] ;
+    sh:property [
+        sh:datatype xsd:date ;
+        sh:path time:inXSDDate ;
+    ] ;
+    sh:property [
+        sh:datatype xsd:dateTimeStamp ;
+        sh:path time:inXSDDateTimeStamp ;
+    ] ;
+    sh:property [
+        sh:datatype xsd:gYear ;
+        sh:path time:inXSDgYear ;
+    ] ;
+    sh:property [
+        sh:datatype xsd:gYearMonth ;
+        sh:path time:inXSDgYearMonth ;
+    ] ;
     sh:and (
-            [
-                sh:property
-                    [
-                        a sh:PropertyShape ;
-                        sh:datatype xsd:dateTime ;
-                        sh:maxCount 1 ;
-                        sh:path time:inDateTime
-                    ] ,
-                    [
-                        a sh:PropertyShape ;
-                        sh:datatype xsd:time ;
-                        sh:maxCount 1 ;
-                        sh:path time:inTimePosition
-                    ] ,
-                    [
-                        a sh:PropertyShape ;
-                        sh:datatype xsd:date ;
-                        sh:maxCount 1 ;
-                        sh:path time:inXSDDate
-                    ] ,
-                    [
-                        a sh:PropertyShape ;
-                        sh:datatype xsd:dateTimeStamp ;
-                        sh:maxCount 1 ;
-                        sh:path time:inXSDDateTimeStamp
-                    ] ,
-                    [
-                        a sh:PropertyShape ;
-                        sh:datatype xsd:gYear ;
-                        sh:maxCount 1 ;
-                        sh:path time:inXSDgYear
-                    ] ,
-                    [
-                        a sh:PropertyShape ;
-                        sh:datatype xsd:gYearMonth ;
-                        sh:maxCount 1 ;
-                        sh:path time:inXSDgYearMonth
-                    ]
+        [
+            sh:property [
+                sh:maxCount 1 ;
+                sh:path time:inDateTime ;
             ]
-            [
-                sh:or (
-                        [
-                            sh:property
-                                [
-                                    a sh:PropertyShape ;
-                                    sh:minCount 1 ;
-                                    sh:path time:inDateTime
-                                ] ,
-                                [
-                                    a sh:PropertyShape ;
-                                    sh:minCount 1 ;
-                                    sh:path time:inTimePosition
-                                ] ,
-                                [
-                                    a sh:PropertyShape ;
-                                    sh:minCount 1 ;
-                                    sh:path time:inXSDDate
-                                ] ,
-                                [
-                                    a sh:PropertyShape ;
-                                    sh:minCount 1 ;
-                                    sh:path time:inXSDDateTimeStamp
-                                ] ,
-                                [
-                                    a sh:PropertyShape ;
-                                    sh:minCount 1 ;
-                                    sh:path time:inXSDgYear
-                                ] ,
-                                [
-                                    a sh:PropertyShape ;
-                                    sh:minCount 1 ;
-                                    sh:path time:inXSDgYearMonth
-                                ]
-                        ]
-                    )
+        ]
+        [
+            sh:property [
+                sh:maxCount 1 ;
+                sh:path time:inTimePosition ;
             ]
-        ) ;
+        ]
+        [
+            sh:property [
+                sh:maxCount 1 ;
+                sh:path time:inXSDDate ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:maxCount 1 ;
+                sh:path time:inXSDDateTimeStamp ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:maxCount 1 ;
+                sh:path time:inXSDgYear ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:maxCount 1 ;
+                sh:path time:inXSDgYearMonth ;
+            ]
+        ]
+    ) ;
+    sh:or (
+        [
+            sh:property [
+                sh:minCount 1 ;
+                sh:path time:inDateTime ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:minCount 1 ;
+                sh:path time:inTimePosition ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:minCount 1 ;
+                sh:path time:inXSDDate ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:minCount 1 ;
+                sh:path time:inXSDDateTimeStamp ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:minCount 1 ;
+                sh:path time:inXSDgYear ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:minCount 1 ;
+                sh:path time:inXSDgYearMonth ;
+            ]
+        ]
+    ) ;
     sh:targetClass time:Instant ;
 .
 


### PR DESCRIPTION
I've:

* put each path in its own property
* separated datatype checks from min/max checks
* fixed the type for `time:inTimePosition`: should be `time:TimePosition`, not `time:time`
* improved the error message by use of `sh:message`

I think this is now correct.