### PR TITLE
remove datatype for dcterms:identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TERN Ontology
 
-The TERN Ontology is an OWL Ontology with SHACL profiles to facilitate the representation of ecological survey data. The TERN Ontology is used as a common information model to represent and facilitate the sharing of survey data across different systems.
+The TERN Ontology is an OWL Ontology with SHACL profiles to facilitate the representation of ecological survey data. The TERN Ontology is used as a common information model to represent and facilitate the sharing of survey data across different systems. 
 
 Online documentation: https://linkeddata.tern.org.au/information-models/tern-ontology
 

--- a/docs/tern.shacl.ttl
+++ b/docs/tern.shacl.ttl
@@ -1564,7 +1564,6 @@ tern-shacl:rdfs-comment
 tern-shacl:dcterms-identifier
     a sh:PropertyShape ;
     rdfs:label "dcterms:identifier" ;
-    sh:datatype xsd:string ;
     sh:name "identifier" ;
     sh:path dcterms:identifier ;
 .


### PR DESCRIPTION
Please can you remove the requirement for a `dcterms:identifier` to be an `xsd:string`? The reason is that we use `dcterms:identifier` with custom datatypes, [as per the SKOS recommentations for `skos:notation`](https://www.w3.org/TR/skos-reference/#L2584) so that we can understand what organisation or system has assigned an ID to something, e.g. a number to a Site in the Geoscience Australia Saites DB might have a custom datatype of `ex:GaSiteID`, not `xsd:string`.