### PR TITLE
Add TERN and EcoPlots profile declaration. Refactor files and shapes base IRI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           ontotools file validate docs/tern.ttl
 
-      - name: Ensure there are no syntax errors in docs/tern.shacl.ttl
+      - name: Ensure there are no syntax errors in docs/tern.shapes.ttl
         run: |
-          ontotools file validate docs/tern.shacl.ttl
+          ontotools file validate docs/tern.shapes.ttl
 
       # Comment below out. Due to blank nodes, the longturtle serializer changes the file even when no content has changed.
 

--- a/docs/ecoplots.profile.ttl
+++ b/docs/ecoplots.profile.ttl
@@ -27,6 +27,6 @@
 <https://w3id.org/tern/profiles/tern/ecoplots/validator> a prof:ResourceDescriptor ;
     dcterms:title "EcoPlots - validator" ;
     dcterms:format "text/turtle" ;
-    prof:hasArtifact "https://ternaustralia.github.io/ontology_tern/tern.ecoplots.shacl.ttl"^^xsd:anyURI ;
+    prof:hasArtifact "https://w3id.org/tern/shapes/tern/ecoplots.ttl"^^xsd:anyURI ;
     prof:hasRole role:validator ;
 .

--- a/docs/ecoplots.profile.ttl
+++ b/docs/ecoplots.profile.ttl
@@ -1,0 +1,32 @@
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix role: <http://www.w3.org/ns/dx/prof/role/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix sdo: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/tern/profiles/ecoplots> a prof:Profile ;
+    dcterms:created "2022-03-02"^^xsd:date ;
+    dcterms:modified "2022-03-02"^^xsd:date ;
+    dcterms:creator
+        [
+            a sdo:Person ;
+            sdo:affiliation <https://w3id.org/tern/resources/a083902d-d821-41be-b663-1d7cb33eea66> ;
+            sdo:email "e.chuc@uq.edu.au" ;
+            sdo:identifier <https://orcid.org/0000-0002-6047-9864> ;
+            sdo:name "Edmond Chuc"
+        ] ;
+    dcterms:title "EcoPlots Profile" ;
+    dcterms:description "This is a profile declaration for the EcoPlots profile of the TERN Ontology. It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary." ;
+    dcterms:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:scopeNote "Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play." ;
+    prof:isProfileOf <https://w3id.org/tern/profiles/tern> ;
+    prof:hasResource <https://w3id.org/tern/profiles/tern/ecoplots/validator> ;
+.
+
+<https://w3id.org/tern/profiles/tern/ecoplots/validator> a prof:ResourceDescriptor ;
+    dcterms:title "EcoPlots - validator" ;
+    dcterms:format "text/turtle" ;
+    prof:hasArtifact "https://ternaustralia.github.io/ontology_tern/tern.ecoplots.shacl.ttl"^^xsd:anyURI ;
+    prof:hasRole role:validator ;
+.

--- a/docs/tern.profile.ttl
+++ b/docs/tern.profile.ttl
@@ -44,6 +44,14 @@
     prof:hasRole role:guidance ;
 .
 
+<https://w3id.org/tern/profiles/tern/cookbook> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology - cookbook" ;
+    dcterms:description "A cookbook of patterns on representing ecological things with the TERN Ontology." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "https://linkeddata.tern.org.au/information-models/tern-ontology/cookbook"^^xsd:anyURI ;
+    prof:hasRole role:guidance ;
+.
+
 <https://w3id.org/tern/profiles/tern/class-and-property-shape-constraints> a prof:ResourceDescriptor ;
     dcterms:title "TERN Ontology - classes, properties and shape constraints" ;
     dcterms:description "A web-based viewer of the TERN Ontology classes, properties and their shape constraints." ;

--- a/docs/tern.profile.ttl
+++ b/docs/tern.profile.ttl
@@ -1,0 +1,69 @@
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix role: <http://www.w3.org/ns/dx/prof/role/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix sdo: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/tern/profiles/tern> a prof:Profile ;
+    dcterms:created "2022-03-02"^^xsd:date ;
+    dcterms:modified "2022-03-02"^^xsd:date ;
+    dcterms:creator
+        [
+            a sdo:Person ;
+            sdo:affiliation <https://w3id.org/tern/resources/a083902d-d821-41be-b663-1d7cb33eea66> ;
+            sdo:email "e.chuc@uq.edu.au" ;
+            sdo:identifier <https://orcid.org/0000-0002-6047-9864> ;
+            sdo:name "Edmond Chuc"
+        ] ;
+    dcterms:title "TERN Ontology Profile" ;
+    dcterms:description "This is a profile declaration for the TERN Ontology. It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary." ;
+    dcterms:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:scopeNote "Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play." ;
+    prof:isProfileOf <http://www.w3.org/ns/sosa/>,
+        <http://www.w3.org/ns/ssn/>,
+        <http://www.w3.org/ns/prov#>,
+        <http://rs.tdwg.org/dwc/terms/> ;
+    prof:hasResource <https://w3id.org/tern/profiles/tern/conceptual-information-model>,
+        <https://w3id.org/tern/profiles/tern/class-and-property-shape-constraints>,
+        <https://w3id.org/tern/profiles/tern/specification>,
+        <https://w3id.org/tern/profiles/tern/validator> ;
+.
+
+<https://w3id.org/tern/resources/a083902d-d821-41be-b663-1d7cb33eea66> a sdo:Organization ;
+    sdo:name "TERN" ;
+    sdo:sameAs <https://ror.org/03wxseg04> ;
+    sdo:url <https://www.tern.org.au> ;
+.
+
+<https://w3id.org/tern/profiles/tern/conceptual-information-model> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology - conceptual information model" ;
+    dcterms:description "An overview of the core concepts of the TERN Ontology." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "https://linkeddata.tern.org.au/information-models/tern-ontology/conceptual-information-model"^^xsd:anyURI ;
+    prof:hasRole role:guidance ;
+.
+
+<https://w3id.org/tern/profiles/tern/class-and-property-shape-constraints> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology - classes, properties and shape constraints" ;
+    dcterms:description "A web-based viewer of the TERN Ontology classes, properties and their shape constraints." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "https://linkeddata.tern.org.au/viewers/tern-ontology"^^xsd:anyURI ;
+    prof:hasRole role:constraints ;
+.
+
+<https://w3id.org/tern/profiles/tern/specification> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology - specification" ;
+    dcterms:description "OGC-style specification of the TERN Ontology." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "https://linkeddata.tern.org.au/information-models/tern-ontology/specification"^^xsd:anyURI ;
+    prof:hasRole role:specification ;
+.
+
+<https://w3id.org/tern/profiles/tern/validator> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology - validator" ;
+    dcterms:description "SHACL shapes for the TERN Ontology." ;
+    dcterms:format "text/turtle" ;
+    prof:hasArtifact "https://ternaustralia.github.io/ontology_tern/tern.shacl.ttl"^^xsd:anyURI ;
+    prof:hasRole role:validator ;
+.

--- a/docs/tern.profile.ttl
+++ b/docs/tern.profile.ttl
@@ -115,3 +115,11 @@
     prof:hasArtifact "http://linked.data.gov.au/def/tern-cv/74aa68d3-28fd-468d-8ff5-7e791d9f7159"^^xsd:anyURI ;
     prof:hasRole role:vocabulary ;
 .
+
+<https://w3id.org/tern/profiles/tern/vocabularies/CI-Role-Code> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - CI Role Code" ;
+    dcterms:description "CI Role Code controlled vocabulary to describe the roles available to the TERN Ontology concepts." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.

--- a/docs/tern.profile.ttl
+++ b/docs/tern.profile.ttl
@@ -67,3 +67,51 @@
     prof:hasArtifact "https://ternaustralia.github.io/ontology_tern/tern.shacl.ttl"^^xsd:anyURI ;
     prof:hasRole role:validator ;
 .
+
+<https://w3id.org/tern/profiles/tern/vocabularies/feature-types> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - feature types" ;
+    dcterms:description "Feature types controlled vocabulary to describe SOSA-based features of interest.";
+    dcterms:format "text/html" ;
+    prof:hasArtifact "http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<https://w3id.org/tern/profiles/tern/vocabularies/observable-properties> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - observable properties" ;
+    dcterms:description "Observable properties controlled vocabulary to describe SOSA-based observations." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "http://linked.data.gov.au/def/tern-cv/5699eca7-9ef0-47a6-bcfb-9306e0e2b85e"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<https://w3id.org/tern/profiles/tern/vocabularies/attributes> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - attributes" ;
+    dcterms:description "Attributes controlled vocabulary to describe facts about any entity." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<https://w3id.org/tern/profiles/tern/vocabularies/units-of-measure> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - units of measure" ;
+    dcterms:description "Unit of measure controlled vocabulary by QUDT" ;
+    dcterms:format "text/turtle" ;
+    prof:hasArtifact "http://qudt.org/vocab/unit/"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<https://w3id.org/tern/profiles/tern/vocabularies/instrument-types> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - instrument types" ;
+    dcterms:description "Instrument types controlled vocabulary to describe the types of instruments used in observations and sampling acts." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "http://linked.data.gov.au/def/tern-cv/a3088b5c-622d-4e25-8a75-4c4961b0dfe8"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<https://w3id.org/tern/profiles/tern/vocabularies/site-types> a prof:ResourceDescriptor ;
+    dcterms:title "TERN Ontology vocabulary - site types" ;
+    dcterms:description "Site types controlled vocabulary to describe the types of ecological survey sites." ;
+    dcterms:format "text/html" ;
+    prof:hasArtifact "http://linked.data.gov.au/def/tern-cv/74aa68d3-28fd-468d-8ff5-7e791d9f7159"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.

--- a/docs/tern.profile.ttl
+++ b/docs/tern.profile.ttl
@@ -64,7 +64,7 @@
     dcterms:title "TERN Ontology - validator" ;
     dcterms:description "SHACL shapes for the TERN Ontology." ;
     dcterms:format "text/turtle" ;
-    prof:hasArtifact "https://ternaustralia.github.io/ontology_tern/tern.shacl.ttl"^^xsd:anyURI ;
+    prof:hasArtifact "https://w3id.org/tern/shapes/tern.ttl"^^xsd:anyURI ;
     prof:hasRole role:validator ;
 .
 

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -1,10 +1,10 @@
-# baseURI: https://w3id.org/tern/shacl/tern/
+# baseURI: https://w3id.org/tern/shapes/tern/
 # imports: http://datashapes.org/dash
 # imports: http://www.opengis.net/ont/geosparql
 # imports: http://www.w3.org/2004/02/skos/core
 # imports: http://www.w3.org/ns/shacl#
 # imports: https://w3id.org/tern/ontologies/tern/
-# prefix: tern-shacl
+# prefix: tern-shapes
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>
@@ -18,12 +18,12 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX ssn: <http://www.w3.org/ns/ssn/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-PREFIX tern-shacl: <https://w3id.org/tern/shacl/tern/>
+PREFIX tern-shapes: <https://w3id.org/tern/shapes/tern/>
 PREFIX time: <http://www.w3.org/2006/time#>
 PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-tern-shacl:
+tern-shapes:
     a owl:Ontology ;
     owl:imports
         <http://datashapes.org/dash> ,
@@ -33,42 +33,42 @@ tern-shacl:
         tern: ;
 .
 
-tern-shacl:Association
+tern-shapes:Association
     a sh:NodeShape ;
     sh:property
-        tern-shacl:prov-agent ,
-        tern-shacl:prov-hadRole ;
+        tern-shapes:prov-agent ,
+        tern-shapes:prov-hadRole ;
     sh:targetClass prov:Association ;
 .
 
-tern-shacl:Attribute
+tern-shapes:Attribute
     a sh:NodeShape ;
     sh:property
-        tern-shacl:dcterms-type ,
-        tern-shacl:tern-attribute ,
-        tern-shacl:tern-hasSimpleValue ,
-        tern-shacl:tern-hasValue ,
-        tern-shacl:tern-isAttributeOf ,
-        tern-shacl:void-inDataset ;
+        tern-shapes:dcterms-type ,
+        tern-shapes:tern-attribute ,
+        tern-shapes:tern-hasSimpleValue ,
+        tern-shapes:tern-hasValue ,
+        tern-shapes:tern-isAttributeOf ,
+        tern-shapes:void-inDataset ;
     sh:targetClass tern:Attribute ;
 .
 
-tern-shacl:Attribution
+tern-shapes:Attribution
     a sh:NodeShape ;
     rdfs:label "Attribution" ;
     sh:property
-        tern-shacl:prov-agent ,
-        tern-shacl:prov-hadRole ;
+        tern-shapes:prov-agent ,
+        tern-shapes:prov-hadRole ;
     sh:targetClass prov:Attribution ;
 .
 
-tern-shacl:Boolean
+tern-shapes:Boolean
     a sh:NodeShape ;
-    sh:property tern-shacl:Boolean-value ;
+    sh:property tern-shapes:Boolean-value ;
     sh:targetClass tern:Boolean ;
 .
 
-tern-shacl:Dataset
+tern-shapes:Dataset
     a sh:NodeShape ;
     sh:property [
             a sh:PropertyShape ;
@@ -80,71 +80,71 @@ tern-shacl:Dataset
         ] ;
 .
 
-tern-shacl:Date
+tern-shapes:Date
     a sh:NodeShape ;
-    sh:property tern-shacl:Date-value ;
+    sh:property tern-shapes:Date-value ;
     sh:targetClass tern:Date ;
 .
 
-tern-shacl:DateTime
+tern-shapes:DateTime
     a sh:NodeShape ;
-    sh:property tern-shacl:DateTime-value ;
+    sh:property tern-shapes:DateTime-value ;
     sh:targetClass tern:DateTime ;
 .
 
-tern-shacl:Deployment
+tern-shapes:Deployment
     a sh:NodeShape ;
     sh:property
-        tern-shacl:ssn-deployedOnPlatform ,
-        tern-shacl:ssn-deployedSystem ,
-        tern-shacl:tern-hasAttribute ;
+        tern-shapes:ssn-deployedOnPlatform ,
+        tern-shapes:ssn-deployedSystem ,
+        tern-shapes:tern-hasAttribute ;
     sh:targetClass tern:Deployment ;
 .
 
-tern-shacl:Distribution
+tern-shapes:Distribution
     a sh:NodeShape ;
 .
 
-tern-shacl:Duration
+tern-shapes:Duration
     a sh:NodeShape ;
     sh:property
-        tern-shacl:time-numericDuration ,
-        tern-shacl:time-unitType ;
+        tern-shapes:time-numericDuration ,
+        tern-shapes:time-unitType ;
     sh:targetClass time:Duration ;
 .
 
-tern-shacl:FeatureOfInterest
+tern-shapes:FeatureOfInterest
     a sh:NodeShape ;
     sh:property
-        tern-shacl:FeatureOfInterest-featureType ,
-        tern-shacl:dcterms-identifier ,
-        tern-shacl:dcterms-type ,
-        tern-shacl:geo-hasGeometry ,
-        tern-shacl:prov-qualifiedAttribution ,
-        tern-shacl:prov-wasAttributedTo ,
-        tern-shacl:rdfs-comment ,
-        tern-shacl:sosa-hasSample ,
-        tern-shacl:sosa-isFeatureOfInterestOf ,
-        tern-shacl:void-inDataset ;
+        tern-shapes:FeatureOfInterest-featureType ,
+        tern-shapes:dcterms-identifier ,
+        tern-shapes:dcterms-type ,
+        tern-shapes:geo-hasGeometry ,
+        tern-shapes:prov-qualifiedAttribution ,
+        tern-shapes:prov-wasAttributedTo ,
+        tern-shapes:rdfs-comment ,
+        tern-shapes:sosa-hasSample ,
+        tern-shapes:sosa-isFeatureOfInterestOf ,
+        tern-shapes:void-inDataset ;
     sh:targetClass tern:FeatureOfInterest ;
 .
 
-tern-shacl:Float
+tern-shapes:Float
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Float-uncertainty ,
-        tern-shacl:Float-value ,
-        tern-shacl:tern-unit ;
+        tern-shapes:Float-uncertainty ,
+        tern-shapes:Float-value ,
+        tern-shapes:tern-unit ;
     sh:targetClass tern:Float ;
 .
 
-tern-shacl:IRI
+tern-shapes:IRI
     a sh:NodeShape ;
-    sh:property tern-shacl:IRI-value ;
+    sh:property tern-shapes:IRI-value ;
     sh:targetClass tern:IRI ;
 .
 
-tern-shacl:Instant
+tern-shapes:Instant
     a sh:NodeShape ;
     sh:and (
             [
@@ -251,25 +251,25 @@ tern-shacl:Instant
     sh:targetClass time:Instant ;
 .
 
-tern-shacl:Integer
+tern-shapes:Integer
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Integer-uncertainty ,
-        tern-shacl:Integer-value ,
-        tern-shacl:tern-unit ;
+        tern-shapes:Integer-uncertainty ,
+        tern-shapes:Integer-value ,
+        tern-shapes:tern-unit ;
     sh:targetClass tern:Integer ;
 .
 
-tern-shacl:Interval
+tern-shapes:Interval
     a sh:NodeShape ;
     sh:property
-        tern-shacl:time-hasBeginning ,
-        tern-shacl:time-hasDuration ,
-        tern-shacl:time-hasEnd ;
+        tern-shapes:time-hasBeginning ,
+        tern-shapes:time-hasDuration ,
+        tern-shapes:time-hasEnd ;
     sh:targetClass time:Interval ;
 .
 
-tern-shacl:ManagedFeature
+tern-shapes:ManagedFeature
     a sh:NodeShape ;
     sh:property
         [
@@ -287,222 +287,222 @@ tern-shacl:ManagedFeature
         ] ;
 .
 
-tern-shacl:MaterialSample
+tern-shapes:MaterialSample
     a sh:NodeShape ;
-    sh:property tern-shacl:dwc-materialSampleID ;
+    sh:property tern-shapes:dwc-materialSampleID ;
     sh:targetClass tern:MaterialSample ;
 .
 
-tern-shacl:Observation
+tern-shapes:Observation
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Observation-hasResult ,
-        tern-shacl:dcterms-identifier ,
-        tern-shacl:dcterms-type ,
-        tern-shacl:geo-hasGeometry ,
-        tern-shacl:prov-qualifiedAssociation ,
-        tern-shacl:prov-wasAssociatedWith ,
-        tern-shacl:rdfs-comment ,
-        tern-shacl:sosa-hasFeatureOfInterest ,
-        tern-shacl:sosa-hasSimpleResult ,
-        tern-shacl:sosa-madeBySensor ,
-        tern-shacl:sosa-observedProperty ,
-        tern-shacl:sosa-phenomenonTime ,
-        tern-shacl:sosa-resultTime ,
-        tern-shacl:sosa-usedProcedure ,
-        tern-shacl:tern-hasSiteVisit ,
-        tern-shacl:tern-observationType ,
-        tern-shacl:void-inDataset ;
+        tern-shapes:Observation-hasResult ,
+        tern-shapes:dcterms-identifier ,
+        tern-shapes:dcterms-type ,
+        tern-shapes:geo-hasGeometry ,
+        tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-wasAssociatedWith ,
+        tern-shapes:rdfs-comment ,
+        tern-shapes:sosa-hasFeatureOfInterest ,
+        tern-shapes:sosa-hasSimpleResult ,
+        tern-shapes:sosa-madeBySensor ,
+        tern-shapes:sosa-observedProperty ,
+        tern-shapes:sosa-phenomenonTime ,
+        tern-shapes:sosa-resultTime ,
+        tern-shapes:sosa-usedProcedure ,
+        tern-shapes:tern-hasSiteVisit ,
+        tern-shapes:tern-observationType ,
+        tern-shapes:void-inDataset ;
     sh:targetClass tern:Observation ;
 .
 
-tern-shacl:ObservationCollection
+tern-shapes:ObservationCollection
     a sh:NodeShape ;
     sh:property
-        tern-shacl:ObservationCollection-hasFeatureOfInterest ,
-        tern-shacl:ObservationCollection-hasMember ,
-        tern-shacl:ObservationCollection-hasUltimateFeatureOfInterest ,
-        tern-shacl:ObservationCollection-madeBySensor ,
-        tern-shacl:ObservationCollection-observedProperty ,
-        tern-shacl:ObservationCollection-phenomenonTime ,
-        tern-shacl:ObservationCollection-resultTime ,
-        tern-shacl:ObservationCollection-usedProcedure ;
+        tern-shapes:ObservationCollection-hasFeatureOfInterest ,
+        tern-shapes:ObservationCollection-hasMember ,
+        tern-shapes:ObservationCollection-hasUltimateFeatureOfInterest ,
+        tern-shapes:ObservationCollection-madeBySensor ,
+        tern-shapes:ObservationCollection-observedProperty ,
+        tern-shapes:ObservationCollection-phenomenonTime ,
+        tern-shapes:ObservationCollection-resultTime ,
+        tern-shapes:ObservationCollection-usedProcedure ;
     sh:targetClass tern:ObservationCollection ;
 .
 
-tern-shacl:Quadrat
+tern-shapes:Quadrat
     a sh:NodeShape ;
-    sh:property tern-shacl:Quadrat-featureType ;
+    sh:property tern-shapes:Quadrat-featureType ;
     sh:targetClass tern:Quadrat ;
 .
 
-tern-shacl:RDFDataset
+tern-shapes:RDFDataset
     a sh:NodeShape ;
     sh:property
-        tern-shacl:RDFDataset-contributor ,
-        tern-shacl:RDFDataset-created ,
-        tern-shacl:RDFDataset-creator ,
-        tern-shacl:RDFDataset-date ,
-        tern-shacl:RDFDataset-description ,
-        tern-shacl:RDFDataset-issued ,
-        tern-shacl:RDFDataset-license ,
-        tern-shacl:RDFDataset-modified ,
-        tern-shacl:RDFDataset-publisher ,
-        tern-shacl:RDFDataset-rightsHolder ,
-        tern-shacl:RDFDataset-source ,
-        tern-shacl:RDFDataset-subject ,
-        tern-shacl:RDFDataset-subset ,
-        tern-shacl:RDFDataset-title ,
-        tern-shacl:RDFDataset-vocabulary ;
+        tern-shapes:RDFDataset-contributor ,
+        tern-shapes:RDFDataset-created ,
+        tern-shapes:RDFDataset-creator ,
+        tern-shapes:RDFDataset-date ,
+        tern-shapes:RDFDataset-description ,
+        tern-shapes:RDFDataset-issued ,
+        tern-shapes:RDFDataset-license ,
+        tern-shapes:RDFDataset-modified ,
+        tern-shapes:RDFDataset-publisher ,
+        tern-shapes:RDFDataset-rightsHolder ,
+        tern-shapes:RDFDataset-source ,
+        tern-shapes:RDFDataset-subject ,
+        tern-shapes:RDFDataset-subset ,
+        tern-shapes:RDFDataset-title ,
+        tern-shapes:RDFDataset-vocabulary ;
     sh:targetClass tern:RDFDataset ;
 .
 
-tern-shacl:Result
+tern-shapes:Result
     a sh:NodeShape ;
-    sh:property tern-shacl:Result-isResultOf ;
+    sh:property tern-shapes:Result-isResultOf ;
     sh:targetClass tern:Result ;
 .
 
-tern-shacl:Sample
+tern-shapes:Sample
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Sample-isResultOf ,
-        tern-shacl:Sample-isSampleOf ;
+        tern-shapes:Sample-isResultOf ,
+        tern-shapes:Sample-isSampleOf ;
     sh:targetClass tern:Sample ;
 .
 
-tern-shacl:Sampler
+tern-shapes:Sampler
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Sampler-implements ,
-        tern-shacl:sosa-madeSampling ;
+        tern-shapes:Sampler-implements ,
+        tern-shapes:sosa-madeSampling ;
     sh:targetClass tern:Sampler ;
 .
 
-tern-shacl:Sampling
+tern-shapes:Sampling
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Sampling-hasResult ,
-        tern-shacl:Sampling-madeBySampler ,
-        tern-shacl:dcterms-identifier ,
-        tern-shacl:dcterms-type ,
-        tern-shacl:geo-hasGeometry ,
-        tern-shacl:prov-qualifiedAssociation ,
-        tern-shacl:prov-wasAssociatedWith ,
-        tern-shacl:rdfs-comment ,
-        tern-shacl:sosa-hasFeatureOfInterest ,
-        tern-shacl:sosa-resultTime ,
-        tern-shacl:sosa-usedProcedure ,
-        tern-shacl:tern-hasSiteVisit ,
-        tern-shacl:tern-samplingType ;
+        tern-shapes:Sampling-hasResult ,
+        tern-shapes:Sampling-madeBySampler ,
+        tern-shapes:dcterms-identifier ,
+        tern-shapes:dcterms-type ,
+        tern-shapes:geo-hasGeometry ,
+        tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-wasAssociatedWith ,
+        tern-shapes:rdfs-comment ,
+        tern-shapes:sosa-hasFeatureOfInterest ,
+        tern-shapes:sosa-resultTime ,
+        tern-shapes:sosa-usedProcedure ,
+        tern-shapes:tern-hasSiteVisit ,
+        tern-shapes:tern-samplingType ;
     sh:targetClass tern:Sampling ;
 .
 
-tern-shacl:Site
+tern-shapes:Site
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Site-dimension ,
-        tern-shacl:Site-hasSiteVisit ,
-        tern-shacl:Site-label ,
-        tern-shacl:Site-locationProcedure ,
-        tern-shacl:geo-sfWithin ,
-        tern-shacl:tern-locationDescription ,
-        tern-shacl:tern-siteDescription ;
+        tern-shapes:Site-dimension ,
+        tern-shapes:Site-hasSiteVisit ,
+        tern-shapes:Site-label ,
+        tern-shapes:Site-locationProcedure ,
+        tern-shapes:geo-sfWithin ,
+        tern-shapes:tern-locationDescription ,
+        tern-shapes:tern-siteDescription ;
     sh:targetClass tern:Site ;
 .
 
-tern-shacl:SiteVisit
+tern-shapes:SiteVisit
     a sh:NodeShape ;
     sh:property
-        tern-shacl:SiteVisit-endedAtTime ,
-        tern-shacl:SiteVisit-startedAtTime ,
-        tern-shacl:dcterms-identifier ,
-        tern-shacl:dcterms-type ,
-        tern-shacl:prov-qualifiedAssociation ,
-        tern-shacl:prov-wasAssociatedWith ,
-        tern-shacl:tern-locationDescription ,
-        tern-shacl:tern-siteDescription ,
-        tern-shacl:void-inDataset ;
+        tern-shapes:SiteVisit-endedAtTime ,
+        tern-shapes:SiteVisit-startedAtTime ,
+        tern-shapes:dcterms-identifier ,
+        tern-shapes:dcterms-type ,
+        tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-wasAssociatedWith ,
+        tern-shapes:tern-locationDescription ,
+        tern-shapes:tern-siteDescription ,
+        tern-shapes:void-inDataset ;
     sh:targetClass tern:SiteVisit ;
 .
 
-tern-shacl:System
+tern-shapes:System
     a sh:NodeShape ;
     sh:property
-        tern-shacl:System-hasDeployment ,
-        tern-shacl:System-isHostedBy ,
-        tern-shacl:System-systemType ,
-        tern-shacl:dcterms-type ,
-        tern-shacl:sosa-implements ;
+        tern-shapes:System-hasDeployment ,
+        tern-shapes:System-isHostedBy ,
+        tern-shapes:System-systemType ,
+        tern-shapes:dcterms-type ,
+        tern-shapes:sosa-implements ;
     sh:targetClass tern:System ;
 .
 
-tern-shacl:Taxon
+tern-shapes:Taxon
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Taxon-acceptedNameUsage ,
-        tern-shacl:Taxon-acceptedNameUsageID ,
-        tern-shacl:Taxon-class ,
-        tern-shacl:Taxon-cultivarEpithet ,
-        tern-shacl:Taxon-family ,
-        tern-shacl:Taxon-genericName ,
-        tern-shacl:Taxon-genus ,
-        tern-shacl:Taxon-higherClassification ,
-        tern-shacl:Taxon-infragenericEpithet ,
-        tern-shacl:Taxon-infraspecificEpithet ,
-        tern-shacl:Taxon-kingdom ,
-        tern-shacl:Taxon-nameAccordingTo ,
-        tern-shacl:Taxon-nameAccordingToID ,
-        tern-shacl:Taxon-namePublishedIn ,
-        tern-shacl:Taxon-namePublishedInID ,
-        tern-shacl:Taxon-namePublishedInYear ,
-        tern-shacl:Taxon-nomenclaturalCode ,
-        tern-shacl:Taxon-nomenclaturalStatus ,
-        tern-shacl:Taxon-order ,
-        tern-shacl:Taxon-originalNameUsage ,
-        tern-shacl:Taxon-originalNameUsageID ,
-        tern-shacl:Taxon-parentNameUsage ,
-        tern-shacl:Taxon-parentNameUsageID ,
-        tern-shacl:Taxon-phylum ,
-        tern-shacl:Taxon-scientificName ,
-        tern-shacl:Taxon-scientificNameAuthorship ,
-        tern-shacl:Taxon-scientificNameID ,
-        tern-shacl:Taxon-specificEpithet ,
-        tern-shacl:Taxon-subfamily ,
-        tern-shacl:Taxon-subgenus ,
-        tern-shacl:Taxon-taxonConceptID ,
-        tern-shacl:Taxon-taxonID ,
-        tern-shacl:Taxon-taxonRank ,
-        tern-shacl:Taxon-taxonRemarks ,
-        tern-shacl:Taxon-taxonomicStatus ,
-        tern-shacl:Taxon-verbatimTaxonRank ,
-        tern-shacl:Taxon-vernacularName ;
+        tern-shapes:Taxon-acceptedNameUsage ,
+        tern-shapes:Taxon-acceptedNameUsageID ,
+        tern-shapes:Taxon-class ,
+        tern-shapes:Taxon-cultivarEpithet ,
+        tern-shapes:Taxon-family ,
+        tern-shapes:Taxon-genericName ,
+        tern-shapes:Taxon-genus ,
+        tern-shapes:Taxon-higherClassification ,
+        tern-shapes:Taxon-infragenericEpithet ,
+        tern-shapes:Taxon-infraspecificEpithet ,
+        tern-shapes:Taxon-kingdom ,
+        tern-shapes:Taxon-nameAccordingTo ,
+        tern-shapes:Taxon-nameAccordingToID ,
+        tern-shapes:Taxon-namePublishedIn ,
+        tern-shapes:Taxon-namePublishedInID ,
+        tern-shapes:Taxon-namePublishedInYear ,
+        tern-shapes:Taxon-nomenclaturalCode ,
+        tern-shapes:Taxon-nomenclaturalStatus ,
+        tern-shapes:Taxon-order ,
+        tern-shapes:Taxon-originalNameUsage ,
+        tern-shapes:Taxon-originalNameUsageID ,
+        tern-shapes:Taxon-parentNameUsage ,
+        tern-shapes:Taxon-parentNameUsageID ,
+        tern-shapes:Taxon-phylum ,
+        tern-shapes:Taxon-scientificName ,
+        tern-shapes:Taxon-scientificNameAuthorship ,
+        tern-shapes:Taxon-scientificNameID ,
+        tern-shapes:Taxon-specificEpithet ,
+        tern-shapes:Taxon-subfamily ,
+        tern-shapes:Taxon-subgenus ,
+        tern-shapes:Taxon-taxonConceptID ,
+        tern-shapes:Taxon-taxonID ,
+        tern-shapes:Taxon-taxonRank ,
+        tern-shapes:Taxon-taxonRemarks ,
+        tern-shapes:Taxon-taxonomicStatus ,
+        tern-shapes:Taxon-verbatimTaxonRank ,
+        tern-shapes:Taxon-vernacularName ;
     sh:targetClass tern:Taxon ;
 .
 
-tern-shacl:Text
+tern-shapes:Text
     a sh:NodeShape ;
-    sh:property tern-shacl:Text-value ;
+    sh:property tern-shapes:Text-value ;
     sh:targetClass tern:Text ;
 .
 
-tern-shacl:Transect
+tern-shapes:Transect
     a sh:NodeShape ;
     sh:property
-        tern-shacl:Transect-featureType ,
-        tern-shacl:Transect-hasGeometry ,
-        tern-shacl:Transect-transectDirection ,
-        tern-shacl:Transect-transectEndPoint ,
-        tern-shacl:Transect-transectStartPoint ;
+        tern-shapes:Transect-featureType ,
+        tern-shapes:Transect-hasGeometry ,
+        tern-shapes:Transect-transectDirection ,
+        tern-shapes:Transect-transectEndPoint ,
+        tern-shapes:Transect-transectStartPoint ;
     sh:targetClass tern:Transect ;
 .
 
-tern-shacl:Value
+tern-shapes:Value
     a sh:NodeShape ;
     sh:targetClass tern:Value ;
 .
 
-tern-shacl:Boolean-value
+tern-shapes:Boolean-value
     a sh:PropertyShape ;
     sh:datatype xsd:boolean ;
     sh:maxCount 1 ;
@@ -510,7 +510,7 @@ tern-shacl:Boolean-value
     sh:path rdf:value ;
 .
 
-tern-shacl:Date-value
+tern-shapes:Date-value
     a sh:PropertyShape ;
     sh:datatype xsd:date ;
     sh:maxCount 1 ;
@@ -518,7 +518,7 @@ tern-shacl:Date-value
     sh:path rdf:value ;
 .
 
-tern-shacl:DateTime-value
+tern-shapes:DateTime-value
     a sh:PropertyShape ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
@@ -526,7 +526,7 @@ tern-shacl:DateTime-value
     sh:path rdf:value ;
 .
 
-tern-shacl:FeatureOfInterest-featureType
+tern-shapes:FeatureOfInterest-featureType
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -534,7 +534,7 @@ tern-shacl:FeatureOfInterest-featureType
     sh:path tern:featureType ;
 .
 
-tern-shacl:Float-uncertainty
+tern-shapes:Float-uncertainty
     a sh:PropertyShape ;
     sh:datatype xsd:double ;
     sh:description "Error of measurement (±)." ;
@@ -543,7 +543,7 @@ tern-shacl:Float-uncertainty
     sh:path tern:uncertainty ;
 .
 
-tern-shacl:Float-value
+tern-shapes:Float-value
     a sh:PropertyShape ;
     sh:datatype xsd:double ;
     sh:maxCount 1 ;
@@ -552,7 +552,7 @@ tern-shacl:Float-value
     sh:path rdf:value ;
 .
 
-tern-shacl:IRI-value
+tern-shapes:IRI-value
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -560,7 +560,7 @@ tern-shacl:IRI-value
     sh:path rdf:value ;
 .
 
-tern-shacl:Integer-uncertainty
+tern-shapes:Integer-uncertainty
     a sh:PropertyShape ;
     sh:description "Error of measurement (±)." ;
     sh:maxCount 1 ;
@@ -576,7 +576,7 @@ tern-shacl:Integer-uncertainty
     sh:path tern:uncertainty ;
 .
 
-tern-shacl:Integer-value
+tern-shapes:Integer-value
     a sh:PropertyShape ;
     sh:datatype xsd:integer ;
     sh:maxCount 1 ;
@@ -584,7 +584,7 @@ tern-shacl:Integer-value
     sh:path rdf:value ;
 .
 
-tern-shacl:Observation-hasResult
+tern-shapes:Observation-hasResult
     a sh:PropertyShape ;
     sh:class tern:Value ;
     sh:maxCount 1 ;
@@ -594,7 +594,7 @@ tern-shacl:Observation-hasResult
     sh:path sosa:hasResult ;
 .
 
-tern-shacl:ObservationCollection-hasFeatureOfInterest
+tern-shapes:ObservationCollection-hasFeatureOfInterest
     a sh:PropertyShape ;
     sh:class tern:FeatureOfInterest ;
     sh:description "A relation between an Observation and the entity whose quality was observed, or between an Actuation and the entity whose property was modified, or between an act of Sampling and the entity that was sampled." ;
@@ -604,7 +604,7 @@ tern-shacl:ObservationCollection-hasFeatureOfInterest
     sh:path sosa:hasFeatureOfInterest ;
 .
 
-tern-shacl:ObservationCollection-hasMember
+tern-shapes:ObservationCollection-hasMember
     a sh:PropertyShape ;
     sh:description "Link to a member of a collection of observations that share the same value for one or more of the characteristic properties." ;
     sh:minCount 1 ;
@@ -621,7 +621,7 @@ tern-shacl:ObservationCollection-hasMember
     sh:path sosa:hasMember ;
 .
 
-tern-shacl:ObservationCollection-hasUltimateFeatureOfInterest
+tern-shapes:ObservationCollection-hasUltimateFeatureOfInterest
     a sh:PropertyShape ;
     sh:class tern:FeatureOfInterest ;
     sh:description "Link to the ultimate feature of interest of an observation or act of sampling. This is useful when the proximate feature of interest is a sample of the ultimate feature of interest, directly or transitively." ;
@@ -630,7 +630,7 @@ tern-shacl:ObservationCollection-hasUltimateFeatureOfInterest
     sh:path sosa:hasUltimateFeatureOfInterest ;
 .
 
-tern-shacl:ObservationCollection-madeBySensor
+tern-shapes:ObservationCollection-madeBySensor
     a sh:PropertyShape ;
     sh:class tern:Sensor ;
     sh:description "Relation between an Observation and the Sensor which made the Observations." ;
@@ -640,7 +640,7 @@ tern-shacl:ObservationCollection-madeBySensor
     sh:path sosa:madeBySensor ;
 .
 
-tern-shacl:ObservationCollection-observedProperty
+tern-shapes:ObservationCollection-observedProperty
     a sh:PropertyShape ;
     sh:description "Relation linking an Observation to the property that was observed. The ObservableProperty should be a property of the FeatureOfInterest (linked by hasFeatureOfInterest) of this Observation." ;
     sh:maxCount 1 ;
@@ -649,7 +649,7 @@ tern-shacl:ObservationCollection-observedProperty
     sh:path sosa:observedProperty ;
 .
 
-tern-shacl:ObservationCollection-phenomenonTime
+tern-shapes:ObservationCollection-phenomenonTime
     a sh:PropertyShape ;
     sh:class time:Instant ;
     sh:description "The time that the Result of an Observation, Actuation, or Sampling applies to the FeatureOfInterest. Not necessarily the same as the resultTime. May be an interval or an instant, or some other compound temporal entity." ;
@@ -658,7 +658,7 @@ tern-shacl:ObservationCollection-phenomenonTime
     sh:path sosa:phenomenonTime ;
 .
 
-tern-shacl:ObservationCollection-resultTime
+tern-shapes:ObservationCollection-resultTime
     a sh:PropertyShape ;
     sh:description "The result time is the instant of time when the Observation, Actuation or Sampling activity was completed." ;
     sh:maxCount 1 ;
@@ -678,7 +678,7 @@ tern-shacl:ObservationCollection-resultTime
     sh:path tern:resultDateTime ;
 .
 
-tern-shacl:ObservationCollection-usedProcedure
+tern-shapes:ObservationCollection-usedProcedure
     a sh:PropertyShape ;
     sh:description "A relation to link to a re-usable Procedure used in making an Observation, an Actuation, or a Sample, typically through a Sensor, Actuator or Sampler." ;
     sh:maxCount 1 ;
@@ -687,7 +687,7 @@ tern-shacl:ObservationCollection-usedProcedure
     sh:path sosa:usedProcedure ;
 .
 
-tern-shacl:Quadrat-featureType
+tern-shapes:Quadrat-featureType
     a sh:PropertyShape ;
     sh:hasValue <http://linked.data.gov.au/def/tern-cv/4362c8f2-b3cc-4816-b5a2-fb7bb4c0cff5> ;
     sh:maxCount 1 ;
@@ -697,28 +697,28 @@ tern-shacl:Quadrat-featureType
     sh:path tern:featureType ;
 .
 
-tern-shacl:RDFDataset-contributor
+tern-shapes:RDFDataset-contributor
     a sh:PropertyShape ;
     sh:description "An entity, such as a person, organisation, or service, that is responsible for making contributions to the dataset. The contributor should be described as an RDF resource, rather than just providing the name as a literal." ;
     sh:nodeKind sh:IRI ;
     sh:path dcterms:contributor ;
 .
 
-tern-shacl:RDFDataset-created
+tern-shapes:RDFDataset-created
     a sh:PropertyShape ;
     sh:datatype xsd:date ;
     sh:description "Date of creation of the dataset. The value should be formatted and data-typed as an `xsd:date`." ;
     sh:path dcterms:created ;
 .
 
-tern-shacl:RDFDataset-creator
+tern-shapes:RDFDataset-creator
     a sh:PropertyShape ;
     sh:description "An entity, such as a person, organisation, or service, that is primarily responsible for creating the dataset. The creator should be described as an RDF resource, rather than just providing the name as a literal." ;
     sh:nodeKind sh:IRI ;
     sh:path dcterms:creator ;
 .
 
-tern-shacl:RDFDataset-date
+tern-shapes:RDFDataset-date
     a sh:PropertyShape ;
     sh:datatype xsd:date ;
     sh:description "A point or period of time associated with an event in the life-cycle of the resource. The value should be formatted and data-typed as an `xsd:date`." ;
@@ -726,7 +726,7 @@ tern-shacl:RDFDataset-date
     sh:path dcterms:date ;
 .
 
-tern-shacl:RDFDataset-description
+tern-shapes:RDFDataset-description
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:description "A textual description of the dataset." ;
@@ -734,7 +734,7 @@ tern-shacl:RDFDataset-description
     sh:path dcterms:description ;
 .
 
-tern-shacl:RDFDataset-issued
+tern-shapes:RDFDataset-issued
     a sh:PropertyShape ;
     sh:datatype xsd:date ;
     sh:description "Date of formal issuance (e.g., publication) of the dataset. The value should be formatted and datatyped as an `xsd:date`." ;
@@ -742,7 +742,7 @@ tern-shacl:RDFDataset-issued
     sh:path dcterms:issued ;
 .
 
-tern-shacl:RDFDataset-license
+tern-shapes:RDFDataset-license
     a sh:PropertyShape ;
     sh:description "A legal document giving official permission to do something with the resource." ;
     sh:name "license" ;
@@ -750,14 +750,14 @@ tern-shacl:RDFDataset-license
     sh:path dcterms:license ;
 .
 
-tern-shacl:RDFDataset-modified
+tern-shapes:RDFDataset-modified
     a sh:PropertyShape ;
     sh:datatype xsd:date ;
     sh:description "Date on which the dataset was changed. The value should be formatted and datatyped as an `xsd:date`." ;
     sh:path dcterms:modified ;
 .
 
-tern-shacl:RDFDataset-publisher
+tern-shapes:RDFDataset-publisher
     a sh:PropertyShape ;
     sh:description "An entity, such as a person, organisation, or service, that is responsible for making the dataset available. The publisher should be described as an RDF resource, rather than just providing the name as a literal." ;
     sh:name "publisher" ;
@@ -765,28 +765,28 @@ tern-shacl:RDFDataset-publisher
     sh:path dcterms:publisher ;
 .
 
-tern-shacl:RDFDataset-rightsHolder
+tern-shapes:RDFDataset-rightsHolder
     a sh:PropertyShape ;
     sh:description "A person or organization owning or managing rights over the resource." ;
     sh:name "rights holder" ;
     sh:path dcterms:rightsHolder ;
 .
 
-tern-shacl:RDFDataset-source
+tern-shapes:RDFDataset-source
     a sh:PropertyShape ;
     sh:description "A related resource from which the dataset is derived. The source should be described as an RDF resource, rather than as a literal." ;
     sh:nodeKind sh:IRI ;
     sh:path dcterms:source ;
 .
 
-tern-shacl:RDFDataset-subject
+tern-shapes:RDFDataset-subject
     a sh:PropertyShape ;
     sh:description "A topic of the resource. Recommended practice is to refer to the subject with a URI. If this is not possible or feasible, a literal value that identifies the subject may be provided. Both should preferably refer to a subject in a controlled vocabulary." ;
     sh:nodeKind sh:IRIOrLiteral ;
     sh:path dcterms:subject ;
 .
 
-tern-shacl:RDFDataset-subset
+tern-shapes:RDFDataset-subset
     a sh:PropertyShape ;
     sh:class void:Dataset ;
     sh:description """The `void:subset` property can be used to provide descriptions of parts of a dataset. A part of a dataset is itself a `void:Dataset`, and any of the annotations for datasets listed in this guide can be applied to the subset. Reasons for subdividing a dataset might include:
@@ -801,7 +801,7 @@ tern-shacl:RDFDataset-subset
     sh:path void:subset ;
 .
 
-tern-shacl:RDFDataset-title
+tern-shapes:RDFDataset-title
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:description "The name of the dataset." ;
@@ -809,7 +809,7 @@ tern-shacl:RDFDataset-title
     sh:path dcterms:title ;
 .
 
-tern-shacl:RDFDataset-vocabulary
+tern-shapes:RDFDataset-vocabulary
     a sh:PropertyShape ;
     sh:description "A vocabulary or `owl:Ontology` whose classes or properties are used in a `void:Dataset`." ;
     sh:name "vocabulary" ;
@@ -817,7 +817,7 @@ tern-shacl:RDFDataset-vocabulary
     sh:path void:vocabulary ;
 .
 
-tern-shacl:Result-isResultOf
+tern-shapes:Result-isResultOf
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -834,7 +834,7 @@ tern-shacl:Result-isResultOf
     sh:path sosa:isResultOf ;
 .
 
-tern-shacl:Sample-isResultOf
+tern-shapes:Sample-isResultOf
     a sh:PropertyShape ;
     sh:class tern:Sampling ;
     sh:minCount 1 ;
@@ -843,7 +843,7 @@ tern-shacl:Sample-isResultOf
     sh:path sosa:isResultOf ;
 .
 
-tern-shacl:Sample-isSampleOf
+tern-shapes:Sample-isSampleOf
     a sh:PropertyShape ;
     sh:class tern:FeatureOfInterest ;
     sh:minCount 1 ;
@@ -852,7 +852,7 @@ tern-shacl:Sample-isSampleOf
     sh:path sosa:isSampleOf ;
 .
 
-tern-shacl:Sampler-implements
+tern-shapes:Sampler-implements
     a sh:PropertyShape ;
     sh:description "Relation between an entity that implements a Procedure in some executable way and the Procedure (an algorithm, procedure or method)." ;
     sh:minCount 1 ;
@@ -861,7 +861,7 @@ tern-shacl:Sampler-implements
     sh:path ssn:implements ;
 .
 
-tern-shacl:Sampling-hasResult
+tern-shapes:Sampling-hasResult
     a sh:PropertyShape ;
     sh:class tern:Sample ;
     sh:minCount 1 ;
@@ -870,7 +870,7 @@ tern-shacl:Sampling-hasResult
     sh:path sosa:hasResult ;
 .
 
-tern-shacl:Sampling-madeBySampler
+tern-shapes:Sampling-madeBySampler
     a sh:PropertyShape ;
     sh:class tern:Sampler ;
     sh:description "Relation linking an act of Sampling to the Sampler (sampling device or entity) that made it." ;
@@ -879,35 +879,35 @@ tern-shacl:Sampling-madeBySampler
     sh:path sosa:madeBySampler ;
 .
 
-tern-shacl:Site-dimension
+tern-shapes:Site-dimension
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
     sh:path tern:dimension ;
 .
 
-tern-shacl:Site-hasSiteVisit
+tern-shapes:Site-hasSiteVisit
     a sh:PropertyShape ;
     sh:class tern:SiteVisit ;
     sh:nodeKind sh:IRI ;
     sh:path tern:hasSiteVisit ;
 .
 
-tern-shacl:Site-label
+tern-shapes:Site-label
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
     sh:path rdfs:label ;
 .
 
-tern-shacl:Site-locationProcedure
+tern-shapes:Site-locationProcedure
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:nodeKind sh:IRI ;
     sh:path tern:locationProcedure ;
 .
 
-tern-shacl:SiteVisit-endedAtTime
+tern-shapes:SiteVisit-endedAtTime
     a sh:PropertyShape ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
@@ -915,7 +915,7 @@ tern-shacl:SiteVisit-endedAtTime
     sh:path prov:endedAtTime ;
 .
 
-tern-shacl:SiteVisit-startedAtTime
+tern-shapes:SiteVisit-startedAtTime
     a sh:PropertyShape ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
@@ -924,7 +924,7 @@ tern-shacl:SiteVisit-startedAtTime
     sh:path prov:startedAtTime ;
 .
 
-tern-shacl:System-hasDeployment
+tern-shapes:System-hasDeployment
     a sh:PropertyShape ;
     sh:class tern:Deployment ;
     sh:name "has deployment" ;
@@ -932,7 +932,7 @@ tern-shacl:System-hasDeployment
     sh:path ssn:hasDeployment ;
 .
 
-tern-shacl:System-isHostedBy
+tern-shapes:System-isHostedBy
     a sh:PropertyShape ;
     sh:class tern:Platform ;
     sh:maxCount 1 ;
@@ -941,222 +941,222 @@ tern-shacl:System-isHostedBy
     sh:path sosa:isHostedBy ;
 .
 
-tern-shacl:System-systemType
+tern-shapes:System-systemType
     a sh:PropertyShape ;
     sh:nodeKind sh:IRI ;
     sh:path tern:systemType ;
 .
 
-tern-shacl:Taxon-acceptedNameUsage
+tern-shapes:Taxon-acceptedNameUsage
     a sh:PropertyShape ;
     sh:name "accepted name usage" ;
     sh:path dwc:acceptedNameUsage ;
 .
 
-tern-shacl:Taxon-acceptedNameUsageID
+tern-shapes:Taxon-acceptedNameUsageID
     a sh:PropertyShape ;
     sh:name "accepted name usage ID" ;
     sh:path dwc:acceptedNameUsageID ;
 .
 
-tern-shacl:Taxon-class
+tern-shapes:Taxon-class
     a sh:PropertyShape ;
     sh:path dwc:class ;
 .
 
-tern-shacl:Taxon-cultivarEpithet
+tern-shapes:Taxon-cultivarEpithet
     a sh:PropertyShape ;
     sh:name "cultivar epithet" ;
     sh:path dwc:cultivarEpithet ;
 .
 
-tern-shacl:Taxon-family
+tern-shapes:Taxon-family
     a sh:PropertyShape ;
     sh:path dwc:family ;
 .
 
-tern-shacl:Taxon-genericName
+tern-shapes:Taxon-genericName
     a sh:PropertyShape ;
     sh:name "generic name" ;
     sh:path dwc:genericName ;
 .
 
-tern-shacl:Taxon-genus
+tern-shapes:Taxon-genus
     a sh:PropertyShape ;
     sh:path dwc:genus ;
 .
 
-tern-shacl:Taxon-higherClassification
+tern-shapes:Taxon-higherClassification
     a sh:PropertyShape ;
     sh:name "higher classification" ;
     sh:path dwc:higherClassification ;
 .
 
-tern-shacl:Taxon-infragenericEpithet
+tern-shapes:Taxon-infragenericEpithet
     a sh:PropertyShape ;
     sh:name "infrageneric epithet" ;
     sh:path dwc:infragenericEpithet ;
 .
 
-tern-shacl:Taxon-infraspecificEpithet
+tern-shapes:Taxon-infraspecificEpithet
     a sh:PropertyShape ;
     sh:path dwc:infraspecificEpithet ;
 .
 
-tern-shacl:Taxon-kingdom
+tern-shapes:Taxon-kingdom
     a sh:PropertyShape ;
     sh:path dwc:kingdom ;
 .
 
-tern-shacl:Taxon-nameAccordingTo
+tern-shapes:Taxon-nameAccordingTo
     a sh:PropertyShape ;
     sh:path dwc:nameAccordingTo ;
 .
 
-tern-shacl:Taxon-nameAccordingToID
+tern-shapes:Taxon-nameAccordingToID
     a sh:PropertyShape ;
     sh:name "name according to ID" ;
     sh:path dwc:nameAccordingToID ;
 .
 
-tern-shacl:Taxon-namePublishedIn
+tern-shapes:Taxon-namePublishedIn
     a sh:PropertyShape ;
     sh:name "name published in" ;
     sh:path dwc:namePublishedIn ;
 .
 
-tern-shacl:Taxon-namePublishedInID
+tern-shapes:Taxon-namePublishedInID
     a sh:PropertyShape ;
     sh:name "name published in ID" ;
     sh:path dwc:namePublishedInID ;
 .
 
-tern-shacl:Taxon-namePublishedInYear
+tern-shapes:Taxon-namePublishedInYear
     a sh:PropertyShape ;
     sh:name "name published in year" ;
     sh:path dwc:namePublishedInYear ;
 .
 
-tern-shacl:Taxon-nomenclaturalCode
+tern-shapes:Taxon-nomenclaturalCode
     a sh:PropertyShape ;
     sh:name "nomenclatural code" ;
     sh:path dwc:nomenclaturalCode ;
 .
 
-tern-shacl:Taxon-nomenclaturalStatus
+tern-shapes:Taxon-nomenclaturalStatus
     a sh:PropertyShape ;
     sh:name "nomenclatural status" ;
     sh:path dwc:nomenclaturalStatus ;
 .
 
-tern-shacl:Taxon-order
+tern-shapes:Taxon-order
     a sh:PropertyShape ;
     sh:path dwc:order ;
 .
 
-tern-shacl:Taxon-originalNameUsage
+tern-shapes:Taxon-originalNameUsage
     a sh:PropertyShape ;
     sh:name "original name usage" ;
     sh:path dwc:originalNameUsage ;
 .
 
-tern-shacl:Taxon-originalNameUsageID
+tern-shapes:Taxon-originalNameUsageID
     a sh:PropertyShape ;
     sh:name "original name usage ID" ;
     sh:path dwc:originalNameUsageID ;
 .
 
-tern-shacl:Taxon-parentNameUsage
+tern-shapes:Taxon-parentNameUsage
     a sh:PropertyShape ;
     sh:name "parent name usage" ;
     sh:path dwc:parentNameUsage ;
 .
 
-tern-shacl:Taxon-parentNameUsageID
+tern-shapes:Taxon-parentNameUsageID
     a sh:PropertyShape ;
     sh:name "parent name usage ID" ;
     sh:path dwc:parentNameUsageID ;
 .
 
-tern-shacl:Taxon-phylum
+tern-shapes:Taxon-phylum
     a sh:PropertyShape ;
     sh:path dwc:phylum ;
 .
 
-tern-shacl:Taxon-scientificName
+tern-shapes:Taxon-scientificName
     a sh:PropertyShape ;
     sh:path dwc:scientificName ;
 .
 
-tern-shacl:Taxon-scientificNameAuthorship
+tern-shapes:Taxon-scientificNameAuthorship
     a sh:PropertyShape ;
     sh:path dwc:scientificNameAuthorship ;
 .
 
-tern-shacl:Taxon-scientificNameID
+tern-shapes:Taxon-scientificNameID
     a sh:PropertyShape ;
     sh:name "scientific name ID" ;
     sh:path dwc:scientificNameID ;
 .
 
-tern-shacl:Taxon-specificEpithet
+tern-shapes:Taxon-specificEpithet
     a sh:PropertyShape ;
     sh:path dwc:specificEpithet ;
 .
 
-tern-shacl:Taxon-subfamily
+tern-shapes:Taxon-subfamily
     a sh:PropertyShape ;
     sh:name "subfamily" ;
     sh:path dwc:subfamily ;
 .
 
-tern-shacl:Taxon-subgenus
+tern-shapes:Taxon-subgenus
     a sh:PropertyShape ;
     sh:name "subgenus" ;
     sh:path dwc:subgenus ;
 .
 
-tern-shacl:Taxon-taxonConceptID
+tern-shapes:Taxon-taxonConceptID
     a sh:PropertyShape ;
     sh:path dwc:taxonConceptID ;
 .
 
-tern-shacl:Taxon-taxonID
+tern-shapes:Taxon-taxonID
     a sh:PropertyShape ;
     sh:name "taxon ID" ;
     sh:path dwc:taxonID ;
 .
 
-tern-shacl:Taxon-taxonRank
+tern-shapes:Taxon-taxonRank
     a sh:PropertyShape ;
     sh:name "taxon rank" ;
     sh:path dwc:taxonRank ;
 .
 
-tern-shacl:Taxon-taxonRemarks
+tern-shapes:Taxon-taxonRemarks
     a sh:PropertyShape ;
     sh:path dwc:taxonRemarks ;
 .
 
-tern-shacl:Taxon-taxonomicStatus
+tern-shapes:Taxon-taxonomicStatus
     a sh:PropertyShape ;
     sh:name "taxonomic status" ;
     sh:path dwc:taxonomicStatus ;
 .
 
-tern-shacl:Taxon-verbatimTaxonRank
+tern-shapes:Taxon-verbatimTaxonRank
     a sh:PropertyShape ;
     sh:name "verbatim taxon rank" ;
     sh:path dwc:verbatimTaxonRank ;
 .
 
-tern-shacl:Taxon-vernacularName
+tern-shapes:Taxon-vernacularName
     a sh:PropertyShape ;
     sh:name "vernacular name" ;
     sh:path dwc:vernacularName ;
 .
 
-tern-shacl:Text-value
+tern-shapes:Text-value
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -1171,7 +1171,7 @@ tern-shacl:Text-value
     sh:path rdf:value ;
 .
 
-tern-shacl:Transect-featureType
+tern-shapes:Transect-featureType
     a sh:PropertyShape ;
     sh:hasValue <http://linked.data.gov.au/def/tern-cv/de46fa49-d1c9-4bef-8462-d7ee5174e1e1> ;
     sh:maxCount 1 ;
@@ -1181,7 +1181,7 @@ tern-shacl:Transect-featureType
     sh:path tern:featureType ;
 .
 
-tern-shacl:Transect-hasGeometry
+tern-shapes:Transect-hasGeometry
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:name "has geometry" ;
@@ -1197,7 +1197,7 @@ tern-shacl:Transect-hasGeometry
     sh:path geo:hasGeometry ;
 .
 
-tern-shacl:Transect-transectDirection
+tern-shapes:Transect-transectDirection
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:name "transect direction" ;
@@ -1205,7 +1205,7 @@ tern-shacl:Transect-transectDirection
     sh:path tern:transectDirection ;
 .
 
-tern-shacl:Transect-transectEndPoint
+tern-shapes:Transect-transectEndPoint
     a sh:PropertyShape ;
     sh:class sf:Point ;
     sh:maxCount 1 ;
@@ -1214,7 +1214,7 @@ tern-shacl:Transect-transectEndPoint
     sh:path tern:transectEndPoint ;
 .
 
-tern-shacl:Transect-transectStartPoint
+tern-shapes:Transect-transectStartPoint
     a sh:PropertyShape ;
     sh:class sf:Point ;
     sh:maxCount 1 ;
@@ -1223,28 +1223,28 @@ tern-shacl:Transect-transectStartPoint
     sh:path tern:transectStartPoint ;
 .
 
-tern-shacl:dwc-materialSampleID
+tern-shapes:dwc-materialSampleID
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:nodeKind sh:Literal ;
     sh:path dwc:materialSampleID ;
 .
 
-tern-shacl:geo-sfWithin
+tern-shapes:geo-sfWithin
     a sh:PropertyShape ;
     sh:name "sf within" ;
     sh:nodeKind sh:IRI ;
     sh:path geo:sfWithin ;
 .
 
-tern-shacl:prov-qualifiedAttribution
+tern-shapes:prov-qualifiedAttribution
     a sh:PropertyShape ;
     sh:class prov:Attribution ;
     sh:name "qualified attribution" ;
     sh:path prov:qualifiedAttribution ;
 .
 
-tern-shacl:prov-wasAttributedTo
+tern-shapes:prov-wasAttributedTo
     a sh:PropertyShape ;
     sh:class prov:Agent ;
     sh:name "was attributed to" ;
@@ -1252,7 +1252,7 @@ tern-shacl:prov-wasAttributedTo
     sh:path prov:wasAttributedTo ;
 .
 
-tern-shacl:sosa-hasSample
+tern-shapes:sosa-hasSample
     a sh:PropertyShape ;
     sh:class tern:Sample ;
     sh:name "has sample" ;
@@ -1260,7 +1260,7 @@ tern-shacl:sosa-hasSample
     sh:path sosa:hasSample ;
 .
 
-tern-shacl:sosa-hasSimpleResult
+tern-shapes:sosa-hasSimpleResult
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -1269,14 +1269,14 @@ tern-shacl:sosa-hasSimpleResult
     sh:path sosa:hasSimpleResult ;
 .
 
-tern-shacl:sosa-implements
+tern-shapes:sosa-implements
     a sh:PropertyShape ;
     sh:name "implements" ;
     sh:nodeKind sh:IRI ;
     sh:path ssn:implements ;
 .
 
-tern-shacl:sosa-isFeatureOfInterestOf
+tern-shapes:sosa-isFeatureOfInterestOf
     a sh:PropertyShape ;
     sh:name "is feature of interest of" ;
     sh:nodeKind sh:IRI ;
@@ -1291,7 +1291,7 @@ tern-shacl:sosa-isFeatureOfInterestOf
     sh:path sosa:isFeatureOfInterestOf ;
 .
 
-tern-shacl:sosa-madeBySensor
+tern-shapes:sosa-madeBySensor
     a sh:PropertyShape ;
     sh:class tern:Sensor ;
     sh:description "Relation between an Observation and the Sensor which made the Observations." ;
@@ -1301,7 +1301,7 @@ tern-shacl:sosa-madeBySensor
     sh:path sosa:madeBySensor ;
 .
 
-tern-shacl:sosa-madeSampling
+tern-shapes:sosa-madeSampling
     a sh:PropertyShape ;
     sh:class tern:Sampling ;
     sh:name "made sampling" ;
@@ -1309,7 +1309,7 @@ tern-shacl:sosa-madeSampling
     sh:path sosa:madeSampling ;
 .
 
-tern-shacl:sosa-observedProperty
+tern-shapes:sosa-observedProperty
     a sh:PropertyShape ;
     sh:description "Relation linking an Observation to the property that was observed. The ObservableProperty should be a property of the FeatureOfInterest (linked by hasFeatureOfInterest) of this Observation." ;
     sh:maxCount 1 ;
@@ -1319,7 +1319,7 @@ tern-shacl:sosa-observedProperty
     sh:path sosa:observedProperty ;
 .
 
-tern-shacl:sosa-phenomenonTime
+tern-shapes:sosa-phenomenonTime
     a sh:PropertyShape ;
     sh:class time:Instant ;
     sh:maxCount 1 ;
@@ -1329,7 +1329,7 @@ tern-shacl:sosa-phenomenonTime
     sh:path sosa:phenomenonTime ;
 .
 
-tern-shacl:ssn-deployedOnPlatform
+tern-shapes:ssn-deployedOnPlatform
     a sh:PropertyShape ;
     sh:class tern:Platform ;
     sh:maxCount 1 ;
@@ -1338,7 +1338,7 @@ tern-shacl:ssn-deployedOnPlatform
     sh:path ssn:deployedOnPlatform ;
 .
 
-tern-shacl:ssn-deployedSystem
+tern-shapes:ssn-deployedSystem
     a sh:PropertyShape ;
     sh:class tern:System ;
     sh:name "deployed system" ;
@@ -1346,7 +1346,7 @@ tern-shacl:ssn-deployedSystem
     sh:path ssn:deployedSystem ;
 .
 
-tern-shacl:tern-attribute
+tern-shapes:tern-attribute
     a sh:PropertyShape ;
     sh:description "The identifier of the attribute concept. Attribute concepts are usually described with SKOS controlled vocabularies. TERN manages a list of attributes at [http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924](http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924)." ;
     sh:maxCount 1 ;
@@ -1355,14 +1355,14 @@ tern-shacl:tern-attribute
     sh:path tern:attribute ;
 .
 
-tern-shacl:tern-hasAttribute
+tern-shapes:tern-hasAttribute
     a sh:PropertyShape ;
     sh:class tern:Attribute ;
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:path tern:hasAttribute ;
 .
 
-tern-shacl:tern-hasSimpleValue
+tern-shapes:tern-hasSimpleValue
     a sh:PropertyShape ;
     sh:description "The direct link to the value either as an IRI or an RDF literal. The simple value is always equivalent to the value captured in rdf:value of the tern:Value instance." ;
     sh:maxCount 1 ;
@@ -1372,7 +1372,7 @@ tern-shacl:tern-hasSimpleValue
     sh:path tern:hasSimpleValue ;
 .
 
-tern-shacl:tern-hasValue
+tern-shapes:tern-hasValue
     a sh:PropertyShape ;
     sh:class tern:Value ;
     sh:description "A link to a [tern:Value](https://w3id.org/tern/ontologies/tern/Value) instance which encapsulates the value of this Attribute." ;
@@ -1383,14 +1383,14 @@ tern-shacl:tern-hasValue
     sh:path tern:hasValue ;
 .
 
-tern-shacl:tern-isAttributeOf
+tern-shapes:tern-isAttributeOf
     a sh:PropertyShape ;
     sh:description "A link to the individual which this attribute and its value is applied to. Inverse property of [tern:hasAttribute](https://w3id.org/tern/ontologies/tern/hasAttribute)." ;
     sh:nodeKind sh:IRI ;
     sh:path tern:isAttributeOf ;
 .
 
-tern-shacl:tern-observationType
+tern-shapes:tern-observationType
     a sh:PropertyShape ;
     sh:description "The type of observation." ;
     sh:maxCount 1 ;
@@ -1398,7 +1398,7 @@ tern-shacl:tern-observationType
     sh:path tern:observationType ;
 .
 
-tern-shacl:tern-samplingType
+tern-shapes:tern-samplingType
     a sh:PropertyShape ;
     sh:description "The type of sampling act." ;
     sh:maxCount 1 ;
@@ -1406,7 +1406,7 @@ tern-shacl:tern-samplingType
     sh:path tern:samplingType ;
 .
 
-tern-shacl:time-hasBeginning
+tern-shapes:time-hasBeginning
     a sh:PropertyShape ;
     sh:class time:Instant ;
     sh:maxCount 1 ;
@@ -1415,7 +1415,7 @@ tern-shacl:time-hasBeginning
     sh:path time:hasBeginning ;
 .
 
-tern-shacl:time-hasDuration
+tern-shapes:time-hasDuration
     a sh:PropertyShape ;
     sh:class time:Duration ;
     sh:maxCount 1 ;
@@ -1423,7 +1423,7 @@ tern-shacl:time-hasDuration
     sh:path time:hasDuration ;
 .
 
-tern-shacl:time-hasEnd
+tern-shapes:time-hasEnd
     a sh:PropertyShape ;
     sh:class time:Instant ;
     sh:maxCount 1 ;
@@ -1432,7 +1432,7 @@ tern-shacl:time-hasEnd
     sh:path time:hasEnd ;
 .
 
-tern-shacl:time-numericDuration
+tern-shapes:time-numericDuration
     a sh:PropertyShape ;
     sh:datatype xsd:decimal ;
     sh:maxCount 1 ;
@@ -1441,7 +1441,7 @@ tern-shacl:time-numericDuration
     sh:path time:numericDuration ;
 .
 
-tern-shacl:time-unitType
+tern-shapes:time-unitType
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -1473,7 +1473,7 @@ tern-shacl:time-unitType
     sh:path time:unitType ;
 .
 
-tern-shacl:prov-agent
+tern-shapes:prov-agent
     a sh:PropertyShape ;
     sh:class prov:Agent ;
     sh:maxCount 1 ;
@@ -1482,7 +1482,7 @@ tern-shacl:prov-agent
     sh:path prov:agent ;
 .
 
-tern-shacl:prov-hadRole
+tern-shapes:prov-hadRole
     a sh:PropertyShape ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
@@ -1491,7 +1491,7 @@ tern-shacl:prov-hadRole
     sh:path prov:hadRole ;
 .
 
-tern-shacl:sosa-hasFeatureOfInterest
+tern-shapes:sosa-hasFeatureOfInterest
     a sh:PropertyShape ;
     sh:class tern:FeatureOfInterest ;
     sh:description "A relation between an Observation and the entity whose quality was observed, or between an Actuation and the entity whose property was modified, or between an act of Sampling and the entity that was sampled." ;
@@ -1502,7 +1502,7 @@ tern-shacl:sosa-hasFeatureOfInterest
     sh:path sosa:hasFeatureOfInterest ;
 .
 
-tern-shacl:sosa-resultTime
+tern-shapes:sosa-resultTime
     a sh:PropertyShape ;
     sh:description "The result time is the instant of time when the Observation, Actuation or Sampling activity was completed." ;
     sh:maxCount 1 ;
@@ -1523,7 +1523,7 @@ tern-shacl:sosa-resultTime
     sh:path tern:resultDateTime ;
 .
 
-tern-shacl:sosa-usedProcedure
+tern-shapes:sosa-usedProcedure
     a sh:PropertyShape ;
     sh:description "A relation to link to a re-usable Procedure used in making an Observation, an Actuation, or a Sample, typically through a Sensor, Actuator or Sampler." ;
     sh:maxCount 1 ;
@@ -1533,7 +1533,7 @@ tern-shacl:sosa-usedProcedure
     sh:path sosa:usedProcedure ;
 .
 
-tern-shacl:tern-hasSiteVisit
+tern-shapes:tern-hasSiteVisit
     a sh:PropertyShape ;
     sh:class tern:SiteVisit ;
     sh:maxCount 1 ;
@@ -1541,7 +1541,7 @@ tern-shacl:tern-hasSiteVisit
     sh:path tern:hasSiteVisit ;
 .
 
-tern-shacl:tern-locationDescription
+tern-shapes:tern-locationDescription
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:description """The description of the site's location. 
@@ -1552,7 +1552,7 @@ Example: 10km west of Fletcherview Tropical Rangeland SuperSite.""" ;
     sh:path tern:locationDescription ;
 .
 
-tern-shacl:tern-siteDescription
+tern-shapes:tern-siteDescription
     a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:description """The description of the site. 
@@ -1563,7 +1563,7 @@ Example: Outer fringe of larger lake chain, isolated by reddish dunes, yellow sa
     sh:path tern:siteDescription ;
 .
 
-tern-shacl:tern-unit
+tern-shapes:tern-unit
     a sh:PropertyShape ;
     sh:description "The unit of measure of the value. Use [QUDT units of measure vocabulary](http://qudt.org/vocab/unit/)." ;
     sh:maxCount 1 ;
@@ -1571,7 +1571,7 @@ tern-shacl:tern-unit
     sh:path tern:unit ;
 .
 
-tern-shacl:geo-hasGeometry
+tern-shapes:geo-hasGeometry
     a sh:PropertyShape ;
     sh:class geo:Geometry ;
     sh:name "has geometry" ;
@@ -1579,14 +1579,14 @@ tern-shacl:geo-hasGeometry
     sh:path geo:hasGeometry ;
 .
 
-tern-shacl:prov-qualifiedAssociation
+tern-shapes:prov-qualifiedAssociation
     a sh:PropertyShape ;
     sh:class prov:Association ;
     sh:name "qualified association" ;
     sh:path prov:qualifiedAssociation ;
 .
 
-tern-shacl:prov-wasAssociatedWith
+tern-shapes:prov-wasAssociatedWith
     a sh:PropertyShape ;
     sh:class prov:Agent ;
     sh:name "was associated with" ;
@@ -1594,20 +1594,20 @@ tern-shacl:prov-wasAssociatedWith
     sh:path prov:wasAssociatedWith ;
 .
 
-tern-shacl:rdfs-comment
+tern-shapes:rdfs-comment
     a sh:PropertyShape ;
     sh:nodeKind sh:Literal ;
     sh:path rdfs:comment ;
 .
 
-tern-shacl:dcterms-identifier
+tern-shapes:dcterms-identifier
     a sh:PropertyShape ;
     rdfs:label "dcterms:identifier" ;
     sh:name "identifier" ;
     sh:path dcterms:identifier ;
 .
 
-tern-shacl:void-inDataset
+tern-shapes:void-inDataset
     a sh:PropertyShape ;
     sh:class tern:RDFDataset ;
     sh:description "A link to the RDF payload's metadata which this resource was a part of." ;
@@ -1617,7 +1617,7 @@ tern-shacl:void-inDataset
     sh:path void:inDataset ;
 .
 
-tern-shacl:dcterms-type
+tern-shapes:dcterms-type
     a sh:PropertyShape ;
     rdfs:label "dcterms:type" ;
     sh:description "Useful when [rdfs:subClassOf](http://www.w3.org/2000/01/rdf-schema#subClassOf) entailment is enabled and the proximate class type is required to be recorded." ;


### PR DESCRIPTION
Rename files:
- `tern.shacl.ttl` -> `tern.shapes.ttl`
- `tern.ecoplots.shacl.ttl` -> `tern.ecoplots.shapes.ttl`

Refactor base IRI for `tern.shapes.ttl` to `https://w3id.org/tern/shapes/tern/`

Add profiles for TERN Ontology and EcoPlots.