### PR TITLE
shacl ont version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.0/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT="3.10-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+   && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.0/containers/python-3
+{
+	"name": "Python 3",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": { 
+			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"VARIANT": "3.10-bullseye",
+			// Options
+			"NODE_VERSION": "none"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"python.defaultInterpreterPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"python.linting.pylintArgs": ["--disable=C0111"]
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"ms-vscode.live-server",
+		"stardog-union.stardog-rdf-grammars",
+		"esbenp.prettier-vscode"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -26,14 +26,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 tern-shapes:
     a owl:Ontology ;
     rdfs:label "TERN Ontology Shapes" ;
-    rdfs:comment "SHACL Shapes for the TERN Ontology. The version of this SHACL file is kep in syn with the main TERN Ontology" ;  
+    rdfs:comment "SHACL Shapes for the TERN Ontology. The version number of this SHACL file is kep in sync with the main TERN Ontology" ;  
     owl:imports
         <http://datashapes.org/dash> ,
         <http://www.opengis.net/ont/geosparql> ,
         <http://www.w3.org/2004/02/skos/core> ,
         sh: ,
         tern: ;
-    owl:versionIRI tern:0.5.0 ;
+    owl:versionIRI tern-shapes:0.5.0 ;
     owl:versionInfo "0.5.0" ;        
 .
 

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -33,7 +33,7 @@ tern-shapes:
         <http://www.w3.org/2004/02/skos/core> ,
         sh: ,
         tern: ;
-    owl:versionIRI tern-shapes:0.5.0 ;
+    owl:versionIRI <https://w3id.org/tern/shapes/tern/0.5.0> ;
     owl:versionInfo "0.5.0" ;        
 .
 

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -33,8 +33,8 @@ tern-shapes:
         <http://www.w3.org/2004/02/skos/core> ,
         sh: ,
         tern: ;
-    owl:versionIRI <https://w3id.org/tern/shapes/tern/0.5.0> ;
-    owl:versionInfo "0.5.0" ;        
+    owl:versionIRI <https://w3id.org/tern/shapes/tern/0.5.1> ;
+    owl:versionInfo "0.5.1" ;
 .
 
 tern-shapes:Association

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -25,12 +25,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 tern-shapes:
     a owl:Ontology ;
+    rdfs:label "TERN Ontology Shapes" ;
+    rdfs:comment "SHACL Shapes for the TERN Ontology. The version of this SHACL file is kep in syn with the main TERN Ontology" ;
+    rdfs:isDefinedBy dwc: ;    
     owl:imports
         <http://datashapes.org/dash> ,
         <http://www.opengis.net/ont/geosparql> ,
         <http://www.w3.org/2004/02/skos/core> ,
         sh: ,
         tern: ;
+    owl:versionIRI tern:0.5.0 ;
+    owl:versionInfo "0.5.0" ;        
 .
 
 tern-shapes:Association

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -26,8 +26,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 tern-shapes:
     a owl:Ontology ;
     rdfs:label "TERN Ontology Shapes" ;
-    rdfs:comment "SHACL Shapes for the TERN Ontology. The version of this SHACL file is kep in syn with the main TERN Ontology" ;
-    rdfs:isDefinedBy dwc: ;    
+    rdfs:comment "SHACL Shapes for the TERN Ontology. The version of this SHACL file is kep in syn with the main TERN Ontology" ;  
     owl:imports
         <http://datashapes.org/dash> ,
         <http://www.opengis.net/ont/geosparql> ,

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -145,8 +145,8 @@ tern:
         sosa: ,
         ssn: ,
         <https://raw.githubusercontent.com/w3c/sdw/gh-pages/ssn-extensions/rdf/ssn-ext.ttl> ;
-    owl:versionIRI <https://w3id.org/tern/ontologies/tern/0.5.0> ;
-    owl:versionInfo "0.5.0" ;
+    owl:versionIRI <https://w3id.org/tern/ontologies/tern/0.5.1> ;
+    owl:versionInfo "0.5.1" ;
     prov:wasGeneratedBy [
             a
                 doap:Project ,

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -145,7 +145,7 @@ tern:
         sosa: ,
         ssn: ,
         <https://raw.githubusercontent.com/w3c/sdw/gh-pages/ssn-extensions/rdf/ssn-ext.ttl> ;
-    owl:versionIRI tern:0.5.0 ;
+    owl:versionIRI <https://w3id.org/tern/ontologies/tern/0.5.0> ;
     owl:versionInfo "0.5.0" ;
     prov:wasGeneratedBy [
             a


### PR DESCRIPTION
Just adding versioning info to the SHACL file, just like the ont.

I've also notices that namespaced IRIs with dots in them, like `tern:0.5.0` break in the rdflib.js Turtle parser, so I've replaced the namespaces versionIRI IRIs with full IRIs.