### PR TITLE
Allow instances of Value to be BlankNodes

### DIFF
--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -1547,7 +1547,7 @@ tern-shapes:tern-hasValue
     sh:maxCount 1 ;
     sh:minCount 1 ;
     sh:name "tern:hasValue" ;
-    sh:nodeKind sh:IRI ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
     sh:path tern:hasValue ;
 .
 


### PR DESCRIPTION
I find that I want to be able to create Value instances used to store values, units of measure etc. but in some instances - perhaps most - the value is only needed once, therefore a BlankNode is appropriate, not just an IRI. So can we please allow BNs & IRIs, not just IRIs, as per this PR?