### PR TITLE
Update SHACL description of sosa:isResultOf on tern:Result shape

### DIFF
--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -1066,7 +1066,7 @@ tern-shapes:Result-isResultOf
     skos:prefLabel "is result of" ;
     sh:description "Relation linking a Result to the Observation or Actuation or act of Sampling that created or caused it." ;
     sh:maxCount 1 ;
-    sh:message "A `tern:Result` _MUST_ have exactly 1 `sosa:isResultOf` predicate where the value node is an IRI of type `tern:Observation` or `tern:Sampling`." ;
+    sh:message "A `tern:Result` _MAY_ have at most 1 `sosa:isResultOf` predicate where the value node is an IRI of type `tern:Observation` or `tern:Sampling`." ;
     sh:name "sosa:isResultOf" ;
     sh:nodeKind sh:IRI ;
     sh:or (

--- a/spec/source/core/class-tern:Result.adoc
+++ b/spec/source/core/class-tern:Result.adoc
@@ -27,8 +27,8 @@
 | Label | is result of
 | Definition | Relation linking a Result to the Observation or Actuation or act of Sampling that created or caused it.
 | Scope note | 
-| Implementation | A `tern:Result` _MUST_ have exactly 1 `sosa:isResultOf` predicate where the value node is an IRI of type `tern:Observation` or `tern:Sampling`.
-| Cardinality | Exactly 1
+| Implementation | A `tern:Result` _MAY_ have at most 1 `sosa:isResultOf` predicate where the value node is an IRI of type `tern:Observation` or `tern:Sampling`.
+| Cardinality | Maximum 1
 | Node kind | link:http://www.w3.org/ns/shacl#IRI[`sh:IRI`]
 | Class type | link:https://w3id.org/tern/ontologies/tern/Observation[`tern:Observation`] +
 link:https://w3id.org/tern/ontologies/tern/Sampling[`tern:Sampling`]


### PR DESCRIPTION
Related: https://github.com/ternaustralia/ontology_tern/pull/193

This fixes the `sh:message` to reflect the new shape rules.