### PR TITLE
Subclassing SiteVisit to Survey to Activity

### DIFF
--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -419,7 +419,7 @@ tern-shapes:SiteVisit
         tern-shapes:dcterms-identifier ,
         tern-shapes:dcterms-type ,
         tern-shapes:tern-locationDescription ,
-        tern-shapes:tern-siteDescription ,
+        tern-shapes:tern-siteDescription ;
     sh:targetClass tern:SiteVisit ;
 .
 

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -239,8 +239,8 @@ tern-shapes:Intervention
     a sh:NodeShape ;
     rdfs:label "Intervention" ;
     sh:property
-        tern-shapes:Intervention-endedAtTime ,
-        tern-shapes:Intervention-startedAtTime ,
+        tern-shapes:prov-endedAtTime ,
+        tern-shapes:prov-startedAtTime ,
         tern-shapes:dcterms-identifier ,
         tern-shapes:dcterms-type ,
         tern-shapes:geo-hasGeometry ,
@@ -416,16 +416,23 @@ tern-shapes:SiteVisit
     a sh:NodeShape ;
     rdfs:label "Site Visit" ;
     sh:property
-        tern-shapes:SiteVisit-endedAtTime ,
-        tern-shapes:SiteVisit-startedAtTime ,
         tern-shapes:dcterms-identifier ,
         tern-shapes:dcterms-type ,
-        tern-shapes:prov-qualifiedAssociation ,
-        tern-shapes:prov-wasAssociatedWith ,
         tern-shapes:tern-locationDescription ,
         tern-shapes:tern-siteDescription ,
-        tern-shapes:void-inDataset ;
     sh:targetClass tern:SiteVisit ;
+.
+
+tern-shapes:Survey
+    a sh:NodeShape ;
+    rdfs:label "Site Visit" ;
+    sh:property
+        tern-shapes:prov-endedAtTime ,
+        tern-shapes:prov-startedAtTime ,
+        tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-wasAssociatedWith ,
+        tern-shapes:void-inDataset ;
+    sh:targetClass tern:Survey ;
 .
 
 tern-shapes:System
@@ -775,27 +782,27 @@ tern-shapes:Integer-value
     sh:path rdf:value ;
 .
 
-tern-shapes:Intervention-endedAtTime
+tern-shapes:prov-endedAtTime
     a sh:PropertyShape ;
     reg:status reg:statusExperimental ;
     skos:prefLabel "ended at time" ;
     sh:datatype xsd:dateTime ;
     sh:description "The time at which an activity ended." ;
     sh:maxCount 1 ;
-    sh:message "A `tern:Intervention` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
+    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
     sh:name "prov:endedAtTime" ;
     sh:nodeKind sh:Literal ;
     sh:path prov:endedAtTime ;
 .
 
-tern-shapes:Intervention-startedAtTime
+tern-shapes:prov-startedAtTime
     a sh:PropertyShape ;
     reg:status reg:statusExperimental ;
     skos:prefLabel "started at time" ;
     sh:datatype xsd:dateTime ;
     sh:description "The time at which an activity started." ;
     sh:maxCount 1 ;
-    sh:message "A `tern:Intervention` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
+    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
     sh:minCount 1 ;
     sh:name "prov:startedAtTime" ;
     sh:nodeKind sh:Literal ;
@@ -1259,33 +1266,6 @@ tern-shapes:Site-locationProcedure
     sh:name "tern:locationProcedure" ;
     sh:nodeKind sh:IRI ;
     sh:path tern:locationProcedure ;
-.
-
-tern-shapes:SiteVisit-endedAtTime
-    a sh:PropertyShape ;
-    reg:status reg:statusStable ;
-    skos:prefLabel "ended at time" ;
-    sh:datatype xsd:dateTime ;
-    sh:description "The time at which an activity ended." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:SiteVisit` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
-    sh:name "prov:endedAtTime" ;
-    sh:nodeKind sh:Literal ;
-    sh:path prov:endedAtTime ;
-.
-
-tern-shapes:SiteVisit-startedAtTime
-    a sh:PropertyShape ;
-    reg:status reg:statusStable ;
-    skos:prefLabel "started at time" ;
-    sh:datatype xsd:dateTime ;
-    sh:description "The time at which an activity started." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:SiteVisit` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
-    sh:minCount 1 ;
-    sh:name "prov:startedAtTime" ;
-    sh:nodeKind sh:Literal ;
-    sh:path prov:startedAtTime ;
 .
 
 tern-shapes:System-hasDeployment

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -425,7 +425,7 @@ tern-shapes:SiteVisit
 
 tern-shapes:Survey
     a sh:NodeShape ;
-    rdfs:label "Site Visit" ;
+    rdfs:label "Survey" ;
     sh:property
         tern-shapes:prov-endedAtTime ,
         tern-shapes:prov-startedAtTime ,

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -1099,9 +1099,17 @@ Taking a diamond-drill core from a rock outcrop.""" ;
 tern:SiteVisit
     a owl:Class ;
     reg:status reg:statusStable ;
-    rdfs:subClassOf prov:Activity ;
-    skos:definition "A Site Visit is a discrete time-bounded activity at a `Site`, during which `Sampling` or `Observation` activities occur." ;
+    rdfs:subClassOf tern:Survey ;
+    skos:definition "A Site Visit is a `Survey` that visits a `Site`." ;
     skos:prefLabel "Site Visit" ;
+.
+
+tern:Survey
+    a owl:Class ;
+    reg:status reg:statusExperimental ;
+    rdfs:subClassOf prov:Activity ;
+    skos:definition "A Survey is an `Activity` during which `Sampling` or `Observation` Activities occur." ;
+    skos:prefLabel "Survey" ;
 .
 
 tern:centroidPoint

--- a/docs/tern.ttl.txt
+++ b/docs/tern.ttl.txt
@@ -38,7 +38,8 @@ title TERN Ontology
 "sosa:Sensor" <|-- ":Sensor"
 "sosa:Procedure" <|-- ":Procedure"
 ":Value" <|-- ":IRI"
-"prov:Activity" <|-- ":SiteVisit"
+"prov:Activity" <|-- ":Survey"
+":Survey" <|-- ":SiteVisit"
 ":Platform" <|-- ":FixedPlatform"
 ":Value" <|-- ":Taxon"
 "dcat:Dataset" <|-- ":Dataset"
@@ -134,6 +135,8 @@ Class ":Procedure" [[https://w3id.org/tern/ontologies/tern/Procedure]] {
 Class ":IRI" [[https://w3id.org/tern/ontologies/tern/IRI]] {
 }
 Class ":SiteVisit" [[https://w3id.org/tern/ontologies/tern/SiteVisit]] {
+}
+Class ":Survey" [[https://w3id.org/tern/ontologies/tern/Survey]] {
 }
 Class ":FixedPlatform" [[https://w3id.org/tern/ontologies/tern/FixedPlatform]] {
 }


### PR DESCRIPTION
Adding a Survey class and making SiteVisit a subclass of it, to allow for Surveys that don't visit Sites.

With this single addition, I think we can cover all/most of DCCEEW's _Systematic Survey Modelling_ issues.

I have updated SHACL too, to match this change. I have also deduplicated `startedAtTime` & `endedAtTime` identical SHACL restrictions.