### PR TITLE
Added new classes and properties based on EMSA surveys

### DIFF
--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -239,12 +239,12 @@ tern-shapes:Intervention
     a sh:NodeShape ;
     rdfs:label "Intervention" ;
     sh:property
-        tern-shapes:prov-endedAtTime ,
-        tern-shapes:prov-startedAtTime ,
         tern-shapes:dcterms-identifier ,
         tern-shapes:dcterms-type ,
         tern-shapes:geo-hasGeometry ,
+        tern-shapes:prov-endedAtTime ,
         tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-startedAtTime ,
         tern-shapes:prov-wasAssociatedWith ,
         tern-shapes:tern-hasAttribute ,
         tern-shapes:tern-interventionType ,
@@ -428,8 +428,8 @@ tern-shapes:Survey
     rdfs:label "Survey" ;
     sh:property
         tern-shapes:prov-endedAtTime ,
-        tern-shapes:prov-startedAtTime ,
         tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-startedAtTime ,
         tern-shapes:prov-wasAssociatedWith ,
         tern-shapes:void-inDataset ;
     sh:targetClass tern:Survey ;
@@ -780,33 +780,6 @@ tern-shapes:Integer-value
     sh:name "rdf:value" ;
     sh:nodeKind sh:Literal ;
     sh:path rdf:value ;
-.
-
-tern-shapes:prov-endedAtTime
-    a sh:PropertyShape ;
-    reg:status reg:statusExperimental ;
-    skos:prefLabel "ended at time" ;
-    sh:datatype xsd:dateTime ;
-    sh:description "The time at which an activity ended." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
-    sh:name "prov:endedAtTime" ;
-    sh:nodeKind sh:Literal ;
-    sh:path prov:endedAtTime ;
-.
-
-tern-shapes:prov-startedAtTime
-    a sh:PropertyShape ;
-    reg:status reg:statusExperimental ;
-    skos:prefLabel "started at time" ;
-    sh:datatype xsd:dateTime ;
-    sh:description "The time at which an activity started." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
-    sh:minCount 1 ;
-    sh:name "prov:startedAtTime" ;
-    sh:nodeKind sh:Literal ;
-    sh:path prov:startedAtTime ;
 .
 
 tern-shapes:Observation-hasResult
@@ -2308,6 +2281,33 @@ tern-shapes:time-unitType
     sh:qualifiedValueShape [
             sh:property <urn:shape:geo-sfWithin-min-1>
         ] ;
+.
+
+tern-shapes:prov-endedAtTime
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "ended at time" ;
+    sh:datatype xsd:dateTime ;
+    sh:description "The time at which an activity ended." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
+    sh:name "prov:endedAtTime" ;
+    sh:nodeKind sh:Literal ;
+    sh:path prov:endedAtTime ;
+.
+
+tern-shapes:prov-startedAtTime
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "started at time" ;
+    sh:datatype xsd:dateTime ;
+    sh:description "The time at which an activity started." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
+    sh:minCount 1 ;
+    sh:name "prov:startedAtTime" ;
+    sh:nodeKind sh:Literal ;
+    sh:path prov:startedAtTime ;
 .
 
 tern-shapes:sosa-hasFeatureOfInterest

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -225,6 +225,28 @@ tern:Dimension
     rdfs:subClassOf
         [
             a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:length
+        ] ,
+        [
+            a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:width
+        ] ,
+        [
+            a owl:Restriction ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty tern:length
         ] ,
@@ -238,28 +260,6 @@ tern:Dimension
             owl:onClass <http://qudt.org/schema/qudt/Unit> ;
             owl:onProperty tern:unit ;
             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:length
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:width
         ] ;
     owl:deprecated true ;
     skos:definition "The dimension of a 2D square or rectangular feature. Example, the dimension of a rectangular plot Site. This class should perhaps have specialised classes to express not just square or rectangular features but also others such as circular features." ;


### PR DESCRIPTION
The Ecological Monitoring System Australia (EMSA) has been developed by TERN in collaboration with the Australian Government [Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au/) (DCCEEW) to support the [National Landcare Program](https://www.dcceew.gov.au/environment/land/landcare).

EMSA has 19+5 modules, presented [here](https://www.tern.org.au/emsa-protocols-manual). TERN has created controlled vocabularies for field survey protocols and is working with the surveillance team to export EMSA data to meet ABIS standards.

This PR added new classes and properties from EMSA surveys, for example, site and quadrat has length and width.