### PR TITLE
Added new classes and properties from DCAT metadata mapping

### DIFF
--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -516,6 +516,16 @@ tern-shapes:Value
     sh:targetClass tern:Value ;
 .
 
+tern-shapes:VerticalExtent
+    a sh:NodeShape ;
+    rdfs:label "Vertical extent" ;
+    sh:property
+        tern-shapes:tern-maxAltitude ,
+        tern-shapes:tern-minAltitude ,
+        tern-shapes:tern-unit ;
+    sh:targetClass tern:VerticalExtent ;
+.
+
 tern-shapes:tern-collaborator
     a sh:PropertyShape ;
     reg:status reg:statusExperimental ;
@@ -601,6 +611,23 @@ tern-shapes:tern-supplementalInformation
     sh:name "tern:supplementalInformation" ;
     sh:nodeKind sh:Literal ;
     sh:path tern:supplementalInformation ;
+.
+
+tern-shapes:tern-verticalExtent
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "vertical extent" ;
+    sh:class tern:VerticalExtent ;
+    sh:description "This SHACL shape defines constraints for the `tern:verticalExtent` property. It specifies that values of the `tern:verticalExtent` property must be IRIs or blank nodes of type `tern:VerticalExtent`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:message "A `tern:verticalExtent` predicate _MUST_ have an IRI or blank node value of type `tern:VerticalExtent`." ;
+    sh:name "tern:verticalExtent" ;
+    sh:nodeKind [
+            sh:in (
+                    sh:IRI
+                    sh:BlankNode
+                )
+        ] ;
+    sh:path tern:verticalExtent ;
 .
 
 tern-shapes:tern-wasInformedBy
@@ -2154,6 +2181,58 @@ tern-shapes:tern-isAttributeOf
     sh:path tern:isAttributeOf ;
 .
 
+tern-shapes:tern-maxAltitude
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "maximum altitude" ;
+    sh:description "This SHACL shape defines constraints for the `tern:maxAltitude` property. It specifies that values of the `tern:maxAltitude` property must be literals of type `xsd:integer`, `xsd:float`, `xsd:double`, or `xsd:decimal`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:maxAltitude` predicate _MUST_ have a literal value of type `xsd:integer`, `xsd:float`, `xsd:double`, `xsd:decimal`." ;
+    sh:name "tern:maxAltitude" ;
+    sh:nodeKind sh:Literal ;
+    sh:or (
+            [
+                sh:datatype xsd:integer
+            ]
+            [
+                sh:datatype xsd:float
+            ]
+            [
+                sh:datatype xsd:double
+            ]
+            [
+                sh:datatype xsd:decimal
+            ]
+        ) ;
+    sh:path tern:maxAltitude ;
+.
+
+tern-shapes:tern-minAltitude
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "minimum altitude" ;
+    sh:description "This SHACL shape defines constraints for the `tern:minAltitude` property. It specifies that values of the `tern:minAltitude` property must be literals of type `xsd:integer`, `xsd:float`, `xsd:double`, or `xsd:decimal`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:minAltitude` predicate _MUST_ have a literal value of type `xsd:integer`, `xsd:float`, `xsd:double`, `xsd:decimal`." ;
+    sh:name "tern:minAltitude" ;
+    sh:nodeKind sh:Literal ;
+    sh:or (
+            [
+                sh:datatype xsd:integer
+            ]
+            [
+                sh:datatype xsd:float
+            ]
+            [
+                sh:datatype xsd:double
+            ]
+            [
+                sh:datatype xsd:decimal
+            ]
+        ) ;
+    sh:path tern:minAltitude ;
+.
+
 tern-shapes:tern-observationType
     a sh:PropertyShape ;
     reg:status reg:statusStable ;
@@ -2493,18 +2572,6 @@ Example: Outer fringe of larger lake chain, isolated by reddish dunes, yellow sa
     sh:path tern:siteDescription ;
 .
 
-tern-shapes:tern-unit
-    a sh:PropertyShape ;
-    reg:status reg:statusStable ;
-    skos:prefLabel "unit of measure" ;
-    sh:description "The unit of measure of the value. Recommended best practice is to use the link:http://qudt.org/vocab/unit/[QUDT units of measure vocabulary]." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:unit` predicate _MUST_ have an IRI value." ;
-    sh:name "tern:unit" ;
-    sh:nodeKind sh:IRI ;
-    sh:path tern:unit ;
-.
-
 <urn:shape:geo-hasGeometry-min-1>
     a sh:PropertyShape ;
     sh:description "At least one geo:hasGeometry must exist." ;
@@ -2530,6 +2597,18 @@ tern-shapes:rdfs-comment
     sh:name "rdfs:comment" ;
     sh:nodeKind sh:Literal ;
     sh:path rdfs:comment ;
+.
+
+tern-shapes:tern-unit
+    a sh:PropertyShape ;
+    reg:status reg:statusStable ;
+    skos:prefLabel "unit of measure" ;
+    sh:description "The unit of measure of the value. Recommended best practice is to use the link:http://qudt.org/vocab/unit/[QUDT units of measure vocabulary]." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:unit` predicate _MUST_ have an IRI value." ;
+    sh:name "tern:unit" ;
+    sh:nodeKind sh:IRI ;
+    sh:path tern:unit ;
 .
 
 tern-shapes:geo-hasGeometry

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -540,6 +540,19 @@ tern-shapes:tern-editor
     sh:path tern:editor ;
 .
 
+tern-shapes:tern-environmentDescription
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "environment description" ;
+    sh:datatype xsd:string ;
+    sh:description "This SHACL shape defines constraints for the `tern:environmentDescription` property. It specifies that values of the `tern:environmentDescription` property must be literals with the datatype `xsd:string`. The maximum cardinality of this property is restricted to one. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:environmentDescription` _MUST_ have a literal value with the datatype `xsd:string`." ;
+    sh:name "tern:environmentDescription" ;
+    sh:nodeKind sh:Literal ;
+    sh:path tern:environmentDescription ;
+.
+
 tern-shapes:tern-funder
     a sh:PropertyShape ;
     reg:status reg:statusExperimental ;
@@ -562,6 +575,32 @@ tern-shapes:tern-producer
     sh:name "tern:producer" ;
     sh:nodeKind sh:IRI ;
     sh:path tern:producer ;
+.
+
+tern-shapes:tern-resourceSpecificUsage
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "resource specific usage" ;
+    sh:datatype xsd:string ;
+    sh:description "This SHACL shape defines constraints for the `tern:resourceSpecificUsage` property. It specifies that values of the `tern:resourceSpecificUsage` property must be literals with the datatype `xsd:string`. The maximum cardinality of this property is restricted to one. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:resourceSpecificUsage` _MUST_ have a literal value with the datatype `xsd:string`." ;
+    sh:name "tern:resourceSpecificUsage" ;
+    sh:nodeKind sh:Literal ;
+    sh:path tern:resourceSpecificUsage ;
+.
+
+tern-shapes:tern-supplementalInformation
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "supplemental information" ;
+    sh:datatype xsd:string ;
+    sh:description "This SHACL shape defines constraints for the `tern:supplementalInformation` property. It specifies that values of the `tern:supplementalInformation` property must be literals with the datatype `xsd:string`. The maximum cardinality of this property is restricted to one. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:supplementalInformation` _MUST_ have a literal value with the datatype `xsd:string`." ;
+    sh:name "tern:supplementalInformation" ;
+    sh:nodeKind sh:Literal ;
+    sh:path tern:supplementalInformation ;
 .
 
 tern-shapes:tern-wasInformedBy

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -239,12 +239,12 @@ tern-shapes:Intervention
     a sh:NodeShape ;
     rdfs:label "Intervention" ;
     sh:property
-        tern-shapes:prov-endedAtTime ,
-        tern-shapes:prov-startedAtTime ,
         tern-shapes:dcterms-identifier ,
         tern-shapes:dcterms-type ,
         tern-shapes:geo-hasGeometry ,
+        tern-shapes:prov-endedAtTime ,
         tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-startedAtTime ,
         tern-shapes:prov-wasAssociatedWith ,
         tern-shapes:tern-hasAttribute ,
         tern-shapes:tern-interventionType ,
@@ -428,8 +428,8 @@ tern-shapes:Survey
     rdfs:label "Survey" ;
     sh:property
         tern-shapes:prov-endedAtTime ,
-        tern-shapes:prov-startedAtTime ,
         tern-shapes:prov-qualifiedAssociation ,
+        tern-shapes:prov-startedAtTime ,
         tern-shapes:prov-wasAssociatedWith ,
         tern-shapes:void-inDataset ;
     sh:targetClass tern:Survey ;
@@ -780,33 +780,6 @@ tern-shapes:Integer-value
     sh:name "rdf:value" ;
     sh:nodeKind sh:Literal ;
     sh:path rdf:value ;
-.
-
-tern-shapes:prov-endedAtTime
-    a sh:PropertyShape ;
-    reg:status reg:statusExperimental ;
-    skos:prefLabel "ended at time" ;
-    sh:datatype xsd:dateTime ;
-    sh:description "The time at which an activity ended." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
-    sh:name "prov:endedAtTime" ;
-    sh:nodeKind sh:Literal ;
-    sh:path prov:endedAtTime ;
-.
-
-tern-shapes:prov-startedAtTime
-    a sh:PropertyShape ;
-    reg:status reg:statusExperimental ;
-    skos:prefLabel "started at time" ;
-    sh:datatype xsd:dateTime ;
-    sh:description "The time at which an activity started." ;
-    sh:maxCount 1 ;
-    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
-    sh:minCount 1 ;
-    sh:name "prov:startedAtTime" ;
-    sh:nodeKind sh:Literal ;
-    sh:path prov:startedAtTime ;
 .
 
 tern-shapes:Observation-hasResult
@@ -2308,6 +2281,33 @@ tern-shapes:time-unitType
     sh:qualifiedValueShape [
             sh:property <urn:shape:geo-sfWithin-min-1>
         ] ;
+.
+
+tern-shapes:prov-endedAtTime
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "ended at time" ;
+    sh:datatype xsd:dateTime ;
+    sh:description "The time at which an activity ended." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MAY_ have a maximum of 1 `prov:endedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
+    sh:name "prov:endedAtTime" ;
+    sh:nodeKind sh:Literal ;
+    sh:path prov:endedAtTime ;
+.
+
+tern-shapes:prov-startedAtTime
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "started at time" ;
+    sh:datatype xsd:dateTime ;
+    sh:description "The time at which an activity started." ;
+    sh:maxCount 1 ;
+    sh:message "A `tern:Survey`, `tern:SiteVisit` or a `tern:Intervention` _MUST_ have exactly 1 `prov:startedAtTime` predicate where the value node is a literal with the datatype `xsd:dateTime`." ;
+    sh:minCount 1 ;
+    sh:name "prov:startedAtTime" ;
+    sh:nodeKind sh:Literal ;
+    sh:path prov:startedAtTime ;
 .
 
 tern-shapes:sosa-hasFeatureOfInterest

--- a/docs/tern.shapes.ttl
+++ b/docs/tern.shapes.ttl
@@ -516,6 +516,54 @@ tern-shapes:Value
     sh:targetClass tern:Value ;
 .
 
+tern-shapes:tern-collaborator
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "collaborator" ;
+    sh:class prov:Agent ;
+    sh:description "This SHACL shape defines constraints for the `tern:collaborator` property. It specifies that values of the `tern:collaborator` property must be IRIs of type `prov:Agent`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:message "A `tern:collaborator` predicate _MUST_ have an IRI value of type `prov:Agent`." ;
+    sh:name "tern:collaborator" ;
+    sh:nodeKind sh:IRI ;
+    sh:path tern:collaborator ;
+.
+
+tern-shapes:tern-editor
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "editor" ;
+    sh:class prov:Agent ;
+    sh:description "This SHACL shape defines constraints for the `tern:editor` property. It specifies that values of the `tern:editor` property must be IRIs of type `prov:Agent`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:message "A `tern:editor` predicate _MUST_ have an IRI value of type `prov:Agent`." ;
+    sh:name "tern:editor" ;
+    sh:nodeKind sh:IRI ;
+    sh:path tern:editor ;
+.
+
+tern-shapes:tern-funder
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "funder" ;
+    sh:class prov:Agent ;
+    sh:description "This SHACL shape defines constraints for the `tern:funder` property. It specifies that values of the `tern:funder` property must be IRIs of type `prov:Agent`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:message "A `tern:funder` predicate _MUST_ have an IRI value of type `prov:Agent`." ;
+    sh:name "tern:funder" ;
+    sh:nodeKind sh:IRI ;
+    sh:path tern:funder ;
+.
+
+tern-shapes:tern-producer
+    a sh:PropertyShape ;
+    reg:status reg:statusExperimental ;
+    skos:prefLabel "producer" ;
+    sh:class prov:Agent ;
+    sh:description "This SHACL shape defines constraints for the `tern:producer` property. It specifies that values of the `tern:producer` property must be IRIs of type `prov:Agent`. The status of this shape is experimental, indicating that it might be subject to change in the future." ;
+    sh:message "A `tern:producer` predicate _MUST_ have an IRI value of type `prov:Agent`." ;
+    sh:name "tern:producer" ;
+    sh:nodeKind sh:IRI ;
+    sh:path tern:producer ;
+.
+
 tern-shapes:tern-wasInformedBy
     a sh:PropertyShape ;
     reg:status reg:statusStable ;

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -226,6 +226,28 @@ tern:Dimension
     rdfs:subClassOf
         [
             a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:length
+        ] ,
+        [
+            a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:width
+        ] ,
+        [
+            a owl:Restriction ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty tern:length
         ] ,
@@ -239,28 +261,6 @@ tern:Dimension
             owl:onClass <http://qudt.org/schema/qudt/Unit> ;
             owl:onProperty tern:unit ;
             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:length
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:width
         ] ;
     owl:deprecated true ;
     skos:definition "The dimension of a 2D square or rectangular feature. Example, the dimension of a rectangular plot Site. This class should perhaps have specialised classes to express not just square or rectangular features but also others such as circular features." ;
@@ -587,6 +587,15 @@ tern:Transect
     skos:scopeNote "There are several types of transects in ecology such as strip transects, line transects, belt transects, point transects and curved line transects." ;
 .
 
+tern:VerticalExtent
+    a owl:Class ;
+    reg:status reg:statusExperimental ;
+    rdfs:subClassOf <http://sweetontology.net/propSpaceHeight/VerticalExtent> ;
+    skos:definition "A class representing the vertical extent of an object or phenomenon in a given context." ;
+    skos:example "The vertical extent of a mountain range." ;
+    skos:prefLabel "Vertical Extent" ;
+.
+
 tern:area
     a rdf:Property ;
     rdfs:label "area" ;
@@ -779,6 +788,20 @@ tern:locationProcedure
     skos:definition "Link to a procedure used to obtain the location." ;
 .
 
+tern:maxAltitude
+    a rdf:Property ;
+    rdfs:label "maximum altitude" ;
+    skos:definition "The maximum altitude of a vertical extent in a given context." ;
+    skos:example "The maximum altitude of a mountain range is 1000m." ;
+.
+
+tern:minAltitude
+    a rdf:Property ;
+    rdfs:label "minimum altitude" ;
+    skos:definition "The minimum altitude of a vertical extent in a given context." ;
+    skos:example "The minimum altitude of a mountain range is 100m." ;
+.
+
 tern:observationType
     a owl:ObjectProperty ;
     rdfs:label "observation type" ;
@@ -918,6 +941,13 @@ tern:valueType
     rdfs:label "value type" ;
     skos:definition "Relates a Property to a specialisation of tern:Value." ;
     skos:example "Use it to describe an instance of sosa:ObservableProperty and its recommended tern:Value type such as tern:QuantitativeMeasure, tern:Boolean, etc." ;
+.
+
+tern:verticalExtent
+    a rdf:Property ;
+    rdfs:label "vertical extent" ;
+    skos:definition "The vertical extent of an object or phenomenon in a given context." ;
+    skos:example "The vertical extent of a mountain range." ;
 .
 
 <https://linked.data.gov.au/org/csiro>

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -226,17 +226,6 @@ tern:Dimension
     rdfs:subClassOf
         [
             a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:width
-        ] ,
-        [
-            a owl:Restriction ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty tern:length
         ] ,
@@ -261,6 +250,17 @@ tern:Dimension
                         )
                 ] ;
             owl:onProperty tern:length
+        ] ,
+        [
+            a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:width
         ] ;
     owl:deprecated true ;
     skos:definition "The dimension of a 2D square or rectangular feature. Example, the dimension of a rectangular plot Site. This class should perhaps have specialised classes to express not just square or rectangular features but also others such as circular features." ;
@@ -637,6 +637,13 @@ tern:editor
     skos:example "Alice Smith is one of editors for ant survey dataset." ;
 .
 
+tern:environmentDescription
+    a rdf:Property ;
+    rdfs:label "environment description" ;
+    skos:definition "The environment description of a dataset." ;
+    skos:example "A dataset collected from weather monitoring stations across the country." ;
+.
+
 tern:featureType
     a owl:ObjectProperty ;
     rdfs:label "feature type" ;
@@ -786,6 +793,13 @@ tern:producer
     skos:example "Alice Smith is one of producers for ant survey dataset." ;
 .
 
+tern:resourceSpecificUsage
+    a rdf:Property ;
+    rdfs:label "resource specific usage" ;
+    skos:definition "The specific usage of resources." ;
+    skos:example "Data analysis for marketing research." ;
+.
+
 tern:resultDateTime
     a owl:DatatypeProperty ;
     rdfs:label "result date time" ;
@@ -839,6 +853,13 @@ tern:stratum
     rdfs:subPropertyOf dcterms:type ;
     skos:definition "A stratum is a distinct, easily seen, layer of foliage and branches of a measurable height." ;
     skos:scopeNote "Value should be from a controlled vocabulary identified by a URI." ;
+.
+
+tern:supplementalInformation
+    a rdf:Property ;
+    rdfs:label "supplemental information" ;
+    skos:definition "The supplemental information of a dataset." ;
+    skos:example "This dataset includes metadata about the data collection process and quality control measures." ;
 .
 
 tern:swPoint

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -14,6 +14,7 @@
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -225,6 +226,28 @@ tern:Dimension
     rdfs:subClassOf
         [
             a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:length
+        ] ,
+        [
+            a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:width
+        ] ,
+        [
+            a owl:Restriction ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty tern:length
         ] ,
@@ -238,28 +261,6 @@ tern:Dimension
             owl:onClass <http://qudt.org/schema/qudt/Unit> ;
             owl:onProperty tern:unit ;
             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:length
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
-            owl:onProperty tern:width
         ] ;
     owl:deprecated true ;
     skos:definition "The dimension of a 2D square or rectangular feature. Example, the dimension of a rectangular plot Site. This class should perhaps have specialised classes to express not just square or rectangular features but also others such as circular features." ;
@@ -769,7 +770,7 @@ tern:resultDateTime
 tern:sampleStorageLocation
     a rdf:Property ;
     rdfs:label "sample storage location" ;
-    rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ;
+    rdfs:subPropertyOf geo:hasGeometry ;
     skos:definition "A property that links a [PhysicalSpecimen](#PhysicalSpecimen) to the location [Point](http://www.opengis.net/ont/sf#Point) of where it is stored." ;
 .
 
@@ -815,7 +816,7 @@ tern:stratum
 tern:swPoint
     a rdf:Property ;
     rdfs:label "sw point" ;
-    rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ;
+    rdfs:subPropertyOf geo:hasGeometry ;
     owl:deprecated true ;
     skos:definition "The south-west point of the subject." ;
 .
@@ -1116,7 +1117,7 @@ tern:centroidPoint
     a rdf:Property ;
     rdfs:label "centroid point" ;
     rdfs:seeAlso <https://en.wikipedia.org/wiki/List_of_centroids> ;
-    rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ;
+    rdfs:subPropertyOf geo:hasGeometry ;
     owl:deprecated true ;
     skos:definition "The centroid point of an object-of-interest." ;
     skos:example """The geometric center of 1-ha vegetation plot expressed 

--- a/docs/tern.ttl
+++ b/docs/tern.ttl
@@ -233,17 +233,6 @@ tern:Dimension
                             xsd:integer
                         )
                 ] ;
-            owl:onProperty tern:length
-        ] ,
-        [
-            a owl:Restriction ;
-            owl:allValuesFrom [
-                    a owl:Class ;
-                    owl:unionOf (
-                            xsd:double
-                            xsd:integer
-                        )
-                ] ;
             owl:onProperty tern:width
         ] ,
         [
@@ -261,6 +250,17 @@ tern:Dimension
             owl:onClass <http://qudt.org/schema/qudt/Unit> ;
             owl:onProperty tern:unit ;
             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
+        ] ,
+        [
+            a owl:Restriction ;
+            owl:allValuesFrom [
+                    a owl:Class ;
+                    owl:unionOf (
+                            xsd:double
+                            xsd:integer
+                        )
+                ] ;
+            owl:onProperty tern:length
         ] ;
     owl:deprecated true ;
     skos:definition "The dimension of a 2D square or rectangular feature. Example, the dimension of a rectangular plot Site. This class should perhaps have specialised classes to express not just square or rectangular features but also others such as circular features." ;
@@ -609,6 +609,13 @@ tern:cardinalDirection
     skos:example "NNE, W, SE, etc." ;
 .
 
+tern:collaborator
+    a rdf:Property ;
+    rdfs:label "collaborator" ;
+    skos:definition "The collaborator of a project." ;
+    skos:example "Alice Smith is one of collaborators for ant survey project." ;
+.
+
 tern:dimension
     a rdf:Property ;
     rdfs:label "dimension" ;
@@ -623,12 +630,26 @@ tern:domain
     skos:example "Vegetation, soil, disturbance, landform, etc." ;
 .
 
+tern:editor
+    a rdf:Property ;
+    rdfs:label "editor" ;
+    skos:definition "The editor of a dataset." ;
+    skos:example "Alice Smith is one of editors for ant survey dataset." ;
+.
+
 tern:featureType
     a owl:ObjectProperty ;
     rdfs:label "feature type" ;
     rdfs:domain tern:FeatureOfInterest ;
     rdfs:range skos:Concept ;
     skos:definition "The feature type of a [Feature of Interest](#FeatureofInterest)." ;
+.
+
+tern:funder
+    a rdf:Property ;
+    rdfs:label "funder" ;
+    skos:definition "The funder of a project." ;
+    skos:example "Environment department is one of funders for ant survey project." ;
 .
 
 tern:globalValue
@@ -756,6 +777,13 @@ tern:observationType
     rdfs:label "observation type" ;
     skos:definition "The type of observation." ;
     skos:example "human observation, machine observation." ;
+.
+
+tern:producer
+    a rdf:Property ;
+    rdfs:label "producer" ;
+    skos:definition "The producer of a dataset." ;
+    skos:example "Alice Smith is one of producers for ant survey dataset." ;
 .
 
 tern:resultDateTime


### PR DESCRIPTION
This PR added new classes and properties used in `ISO19115-3 to TERN DCAT metadata profile` and their SHACL shapes.