### PR TITLE
Added SHACL shapes for DCAT metadata

### DIFF
--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -13,6 +13,7 @@ PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX spdx: <http://spdx.org/rdf/terms#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
 PREFIX time: <http://www.w3.org/2006/time#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -30,11 +31,64 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:minCount 1 ;
             sh:path dcterms:modified ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
         ] ,
         [
             sh:class dcterms:Standard ;
@@ -83,59 +137,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:isPartOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -317,6 +318,39 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:targetClass spdx:Checksum ;
 .
 
+:Concept
+    a sh:NodeShape ;
+    rdfs:label "Concept"@en ;
+    sh:property
+        [
+            sh:message "A `skos:Concept` _MUST_ have at least 1 `skos:prefLabel` where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path skos:prefLabel ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `skos:Concept` _MAY_ have a `tern:unit` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path tern:unit ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `skos:Concept` _MAY_ have a `skos:inScheme` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path skos:inScheme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:anyURI ;
+            sh:message "A `skos:Concept` _MAY_ have a `dcterms:source` where the value node is a literal with the datatype `xsd:anyURI`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass skos:Concept ;
+.
+
 :DataService_Shape
     a sh:NodeShape ;
     rdfs:label "Data Service"@en ;
@@ -440,6 +474,39 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a sh:NodeShape ;
     rdfs:label "Dataset"@en ;
     sh:property
+        [
+            sh:datatype xsd:duration ;
+            sh:maxCount 1 ;
+            sh:path dcat:temporalResolution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:path dcat:spatialResolutionInMeters ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:creator ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
         [
             sh:nodeKind sh:Literal ;
             sh:path dcterms:identifier ;
@@ -572,39 +639,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path prov:wasGeneratedBy ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:duration ;
-            sh:maxCount 1 ;
-            sh:path dcat:temporalResolution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:decimal ;
-            sh:maxCount 1 ;
-            sh:path dcat:spatialResolutionInMeters ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:creator ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:IRI ;
-            sh:path dcatap:applicableLegislation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -2,197 +2,19 @@ PREFIX : <https://w3id.org/tern/shapes/dcat/>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcatap: <http://data.europa.eu/r5r>
-PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX lcon: <http://www.w3.org/ns/locn#>
 PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX spdx: <http://spdx.org/rdf/terms#>
 PREFIX time: <http://www.w3.org/2006/time#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
-:Person_Shape
-    a sh:NodeShape ;
-    rdfs:label "Person"@en ;
-    sh:property
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:message "A `schema:Person` _MUST_ have at least 1 `schema:name` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:name ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:message "A `schema:Person` _MUST_ have at least 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:or (
-                [
-                    sh:nodeKind sh:Literal ;
-                    sh:severity sh:Violation
-                ]
-                [
-                    sh:nodeKind sh:IRI ;
-                    sh:severity sh:Violation
-                ]
-            ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:IRI ;
-            sh:message "A `schema:Person` _MAY_ have a `schema:affiliation` where the value node is an IRI." ;
-            sh:path schema:affiliation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:message "A `schema:Person` _MAY_ have a `schema:email` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:email ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:message "A `schema:Person` _MAY_ have a `schema:telephone` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:telephone ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressCountry` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:addressCountry ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressLocality` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:addressLocality ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressRegion` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:addressRegion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:postalCode` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:postalCode ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:streetAddress` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:streetAddress ;
-            sh:severity sh:Violation
-        ] ,
- ;
-    sh:targetClass schema:Person ;
-.
-
-:Organization_Shape
-    a sh:NodeShape ;
-    rdfs:label "Organization"@en ;
-    sh:property
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:message "A `schema:Organization` _MUST_ have at least 1 `schema:name` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:name ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:message "A `schema:Organization` _MUST_ have at least 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:or (
-                [
-                    sh:nodeKind sh:Literal ;
-                    sh:severity sh:Violation
-                ]
-                [
-                    sh:nodeKind sh:IRI ;
-                    sh:severity sh:Violation
-                ]
-            ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:message "A `schema:Organization` _MAY_ have a `schema:email` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:email ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:message "A `schema:Organization` _MAY_ have a `schema:telephone` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:telephone ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressCountry` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:addressCountry ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressLocality` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:addressLocality ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressRegion` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:addressRegion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:postalCode` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:postalCode ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:streetAddress` where the value node is a literal with the datatype `xsd:string`." ;
-            sh:path schema:streetAddress ;
-            sh:severity sh:Violation
-        ] ,
- ;
-    sh:targetClass schema:Organization ;
-.
 
 :CatalogRecord_Shape
     a sh:NodeShape ;
@@ -200,67 +22,67 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:property
         [
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `foaf:primaryTopic` predicate where the value node is an individual with the type `dcat:Catalog`, or `dcat:Dataset`, or `dcat:DataService`." ;
+            sh:minCount 1 ;
             sh:node :DcatResource_Shape ;
             sh:path foaf:primaryTopic ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:path dct:modified ;
+            sh:minCount 1 ;
+            sh:path dcterms:modified ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
         ] ,
         [
-            sh:maxCount 1 ;
             sh:class dcterms:Standard ;
+            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
-            sh:path dct:conformsTo ;
+            sh:path dcterms:conformsTo ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dct:issued ;
+            sh:path dcterms:issued ;
             sh:severity sh:Violation
         ] ,
         [
+            sh:class skos:Concept ;
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
-            sh:class skos:Concept ;
             sh:path adms:status ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
-            sh:path dct:language ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:language ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
-            sh:path dct:source ;
+            sh:path dcterms:source ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
             sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dct:created ;
+            sh:path dcterms:created ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:nodeKind sh:IRI ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
-            sh:path dct:isPartOf ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:isPartOf ;
             sh:severity sh:Violation
         ] ,
         [
@@ -271,49 +93,49 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
             sh:or (
-                [
-                    sh:nodeKind sh:Literal ;
-                    sh:severity sh:Violation
-                ]
-                [
-                    sh:nodeKind sh:IRI ;
-                    sh:severity sh:Violation
-                ]
-            ) ;
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
             sh:path dcterms:identifier ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:minCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
             sh:or (
-                [
-                    sh:nodeKind schema:Person ;
-                    sh:severity sh:Violation
-                ]
-                [
-                    sh:nodeKind schema:Organization ;
-                    sh:severity sh:Violation
-                ]
-            ) ;
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
             sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:nodeKind sh:Literal ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
-            sh:path dct:title ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:description ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -324,54 +146,54 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Catalog"@en ;
     sh:property
         [
-            sh:path dct:language ;
-            sh:nodeKind sh:IRI ;
             sh:message "A `dcat:Catalog` _MAY_ have a `dcterms:language` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:language ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:nodeKind sh:IRI ;
             sh:message "A `dcat:Catalog` _MAY_ have a `dcatap:applicableLegislation` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
             sh:path dcatap:applicableLegislation ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:message "A `dcat:Catalog` _MAY_ have a maximum of 1 `dcterms:license`." ;
-            sh:path dct:license ;
+            sh:path dcterms:license ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:message "A `dcat:Catalog` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dct:issued ;
+            sh:path dcterms:issued ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:spatial ;
+            sh:path dcterms:spatial ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:hasPart ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dct:isPartOf ;
+            sh:path dcterms:hasPart ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:minCount 1 ;
+            sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
             sh:message "A `dcat:Catalog` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:path dct:modified ;
+            sh:minCount 1 ;
+            sh:path dcterms:modified ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:rights ;
+            sh:path dcterms:rights ;
             sh:severity sh:Violation
         ] ,
         [
@@ -391,59 +213,59 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:creator ;
+            sh:path dcterms:creator ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:nodeKind dcat:Dataset ;
             sh:message "A `dcat:Catalog` _MAY_ have a `dcat:dataset predicate where the value node is a `dcat:Dataset`." ;
+            sh:nodeKind dcat:Dataset ;
             sh:path dcat:dataset ;
             sh:severity sh:Violation
         ] ,
         [
+            sh:message "A `dcat:Catalog` _MUST_ have at least 1 `dcterms:description` where the value node is literal." ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:message "A `dcat:Catalog` _MUST_ have at least 1 `dcterms:description` where the value node is literal." ;
-            sh:path dct:description ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:message "A `dcat:Catalog` _MUST_ have exactly 1 `dcterms:publisher`." ;
-            sh:path dct:publisher ;
+            sh:minCount 1 ;
+            sh:path dcterms:publisher ;
             sh:severity sh:Violation
         ] ,
         [
+            sh:message "A `dcat:Catalog` _MUST_ have at least 1 `dcterms:title` where the value node is literal." ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:message "A `dcat:Catalog` _MUST_ have at least 1 `dcterms:title` where the value node is literal." ;
-            sh:path dct:title ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:message "A `dcat:Catalog` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal with the datatype `xsd:anyURI`." ;
+            sh:minCount 1 ;
             sh:or (
-                [
-                    sh:nodeKind sh:Literal ;
-                    sh:datatype xsd:anyURI ;
-                    sh:severity sh:Violation
-                ]
-                [
-                    sh:nodeKind sh:IRI ;
-                    sh:severity sh:Violation
-                ]
-            ) ;
+                    [
+                        sh:datatype xsd:anyURI ;
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
             sh:path dcterms:identifier ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:maxCount 1 ;
             sh:datatype xsd:anyURI ;
-            sh:nodeKind sh:Literal ;
+            sh:maxCount 1 ;
             sh:message "A `dcat:Catalog` _MAY_ have a maximum of 1 `foaf:homepage` where the value node is a literal with the datatype `xsd:anyURI`." ;
+            sh:nodeKind sh:Literal ;
             sh:path foaf:homepage ;
             sh:severity sh:Violation
         ] ;
@@ -456,7 +278,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:property [
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:title ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass skos:ConceptScheme ;
@@ -502,7 +324,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:title ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ,
         [
@@ -522,7 +344,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:nodeKind sh:Literal ;
-            sh:path dct:description ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ,
         [
@@ -532,12 +354,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:license ;
+            sh:path dcterms:license ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:accessRights ;
+            sh:path dcterms:accessRights ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:DataService ;
@@ -560,45 +382,45 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dct:spatial ;
+            sh:path dcterms:spatial ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dct:accrualPeriodicity ;
+            sh:path dcterms:accrualPeriodicity ;
             sh:severity sh:Violation
         ] ,
         [
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:title ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ,
         [
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:description ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:node :DateOrDateTimeDataType_Shape ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:issued ;
+            sh:path dcterms:issued ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:node :DateOrDateTimeDataType_Shape ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:modified ;
+            sh:path dcterms:modified ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dct:publisher ;
+            sh:path dcterms:publisher ;
             sh:severity sh:Violation
         ] ,
         [
@@ -608,7 +430,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dct:temporal ;
+            sh:path dcterms:temporal ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:DatasetSeries ;
@@ -619,25 +441,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path dct:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:IRI ;
-            sh:path dcatap:applicableLegislation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dct:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dct:identifier ;
+            sh:path dcterms:identifier ;
             sh:severity sh:Violation
         ] ,
         [
@@ -655,15 +460,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:publisher ;
+            sh:path dcterms:publisher ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:spatial ;
+            sh:path dcterms:spatial ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:temporal ;
+            sh:path dcterms:temporal ;
             sh:severity sh:Violation
         ] ,
         [
@@ -672,57 +477,57 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:accessRights ;
+            sh:path dcterms:accessRights ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:accrualPeriodicity ;
+            sh:path dcterms:accrualPeriodicity ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:conformsTo ;
+            sh:path dcterms:conformsTo ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:hasVersion ;
+            sh:path dcterms:hasVersion ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:isVersionOf ;
+            sh:path dcterms:isVersionOf ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:issued ;
+            sh:path dcterms:issued ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
         ] ,
         [
-            sh:path dct:language ;
+            sh:path dcterms:language ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:modified ;
+            sh:path dcterms:modified ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
         ] ,
         [
-            sh:path dct:provenance ;
+            sh:path dcterms:provenance ;
             sh:severity sh:Violation
         ] ,
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dct:relation ;
+            sh:path dcterms:relation ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:source ;
+            sh:path dcterms:source ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:type ;
+            sh:path dcterms:type ;
             sh:severity sh:Violation
         ] ,
         [
@@ -758,7 +563,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dct:isReferencedBy ;
+            sh:path dcterms:isReferencedBy ;
             sh:severity sh:Violation
         ] ,
         [
@@ -782,7 +587,24 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:creator ;
+            sh:path dcterms:creator ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -835,7 +657,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:nodeKind sh:Literal ;
-            sh:path dct:description ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ,
         [
@@ -845,16 +667,16 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:format ;
+            sh:path dcterms:format ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:license ;
+            sh:path dcterms:license ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:conformsTo ;
+            sh:path dcterms:conformsTo ;
             sh:severity sh:Violation
         ] ,
         [
@@ -865,27 +687,27 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:maxCount 1 ;
             sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dct:issued ;
+            sh:path dcterms:issued ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:path dct:language ;
+            sh:path dcterms:language ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
             sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dct:modified ;
+            sh:path dcterms:modified ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
-            sh:path dct:rights ;
+            sh:path dcterms:rights ;
             sh:severity sh:Violation
         ] ,
         [
             sh:nodeKind sh:Literal ;
-            sh:path dct:title ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ,
         [
@@ -921,10 +743,95 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a sh:NodeShape ;
     rdfs:label "Licence Document"@en ;
     sh:property [
-            sh:path dct:type ;
+            sh:path dcterms:type ;
             sh:severity sh:Violation
         ] ;
-    sh:targetClass dct:LicenseDocument ;
+    sh:targetClass dcterms:LicenseDocument ;
+.
+
+:Organization_Shape
+    a sh:NodeShape ;
+    rdfs:label "Organization"@en ;
+    sh:property
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Organization` _MUST_ have at least 1 `schema:name` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:name ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `schema:Organization` _MUST_ have at least 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Organization` _MAY_ have a `schema:email` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:email ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Organization` _MAY_ have a `schema:telephone` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:telephone ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressCountry` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:addressCountry ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressLocality` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:addressLocality ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressRegion` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:addressRegion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:postalCode` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:postalCode ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:streetAddress` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:streetAddress ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass schema:Organization ;
 .
 
 :PeriodOfTime_Shape
@@ -953,7 +860,98 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
         ] ;
-    sh:targetClass dct:PeriodOfTime ;
+    sh:targetClass dcterms:PeriodOfTime ;
+.
+
+:Person_Shape
+    a sh:NodeShape ;
+    rdfs:label "Person"@en ;
+    sh:property
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Person` _MUST_ have at least 1 `schema:name` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:name ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressCountry` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:addressCountry ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressLocality` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:addressLocality ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressRegion` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:addressRegion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:postalCode` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:postalCode ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:streetAddress` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:streetAddress ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `schema:Person` _MUST_ have at least 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `schema:Person` _MAY_ have a `schema:affiliation` where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path schema:affiliation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Person` _MAY_ have a `schema:email` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:email ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Person` _MAY_ have a `schema:telephone` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:telephone ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass schema:Person ;
 .
 
 :DcatResource_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -13,7 +13,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX schema: <https://schema.org/>
+PREFIX schema: <http://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -33,43 +33,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:class dcterms:Standard ;
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
-            sh:path dcterms:conformsTo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
@@ -122,6 +85,22 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
@@ -140,6 +119,27 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dcterms:Standard ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -478,6 +478,53 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:maxCount 1 ;
+            sh:path dcterms:accessRights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:hasVersion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:isVersionOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:provenance ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:relation ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path dcterms:source ;
             sh:severity sh:Violation
         ] ,
@@ -595,53 +642,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path dcat:theme ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accessRights ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accrualPeriodicity ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:conformsTo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:hasVersion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:isVersionOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:issued ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:provenance ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:relation ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -1223,6 +1223,47 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:targetClass dcterms:Standard ;
 .
 
+:VerticalExtent_Shape
+    a sh:NodeShape ;
+    rdfs:label "Vertical Extent"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:message "A `tern:VerticalExtent` _MUST_ have exactly 1 `tern:minAltitude` predicate where the value node is a literal with the datatype `xsd:integer`, `xsd:float`, `xsd:double` or `xsd:decimal`." ;
+            sh:minCount 1 ;
+            sh:node :NumericDataType_Shape ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:minAltitude ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `tern:VerticalExtent` _MUST_ have exactly 1 `tern:maxAltitude` predicate where the value node is a literal with the datatype `xsd:integer`, `xsd:float`, `xsd:double` or `xsd:decimal`." ;
+            sh:minCount 1 ;
+            sh:node :NumericDataType_Shape ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:maxAltitude ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `tern:VerticalExtent` _MUST_ have exactly 1 `tern:unit` predicate where the value node is `sh:IRI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path tern:unit ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `tern:VerticalExtent` _MUST_ have exactly 1 `dcterms:conformsTo` predicate where the value node is `sh:IRI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass tern:VerticalExtent ;
+.
+
 :DcatResource_Shape
     a sh:NodeShape ;
     rdfs:label "dcat:Resource" ;
@@ -1237,6 +1278,27 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             ]
             [
                 sh:class dcat:DataService
+            ]
+        ) ;
+.
+
+:NumericDataType_Shape
+    a sh:NodeShape ;
+    rdfs:label "Numeric datatype" ;
+    rdfs:comment "Numeric datatype shape checks that a datatype property receives a temporal value: integer, float, double or decimal literal" ;
+    sh:message "The values must be data typed as either xsd:integer, xsd:float, xsd:double or xsd:decimal" ;
+    sh:or (
+            [
+                sh:datatype xsd:integer
+            ]
+            [
+                sh:datatype xsd:float
+            ]
+            [
+                sh:datatype xsd:double
+            ]
+            [
+                sh:datatype xsd:decimal
             ]
         ) ;
 .

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -5,6 +5,7 @@ PREFIX dcatap: <http://data.europa.eu/r5r>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX dqv: <http://www.w3.org/ns/dqv#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX oa: <http://www.w3.org/ns/oa#>
 PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -29,39 +30,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:minCount 1 ;
             sh:node :DcatResource_Shape ;
             sh:path foaf:primaryTopic ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ,
         [
@@ -122,6 +90,23 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
             sh:path <http://www.w3.org/2011/content#characterEncoding> ;
@@ -139,6 +124,22 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -477,6 +478,50 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path dcat:distribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dcat:keyword ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:spatial ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:temporal ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:theme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accessRights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:hasVersion ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path dcterms:isVersionOf ;
             sh:severity sh:Violation
         ] ,
@@ -597,50 +642,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:distribution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dcat:keyword ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:publisher ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:spatial ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:temporal ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:theme ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accessRights ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accrualPeriodicity ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:conformsTo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:hasVersion ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -773,6 +774,30 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Distribution ;
+.
+
+:Geometry_Shape
+    a sh:NodeShape ;
+    rdfs:label "Geometry"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:message "A `geo:Geometry` _MUST_ have exactly 1 `tern:locationDescription` predicate where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:locationDescription ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype geo:WKTLiteral ;
+            sh:maxCount 1 ;
+            sh:message "A `geo:Geometry` _MUST_ have exactly 1 `geo:asWKT` where the value node is a literal with the datatype `geo:WKTLiteral`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path geo:asWKT ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass geo:Geometry ;
 .
 
 :LicenceDocument_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -34,43 +34,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:class skos:Concept ;
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
-            sh:path adms:status ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
-            sh:severity sh:Violation
-        ] ,
-        [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:minCount 1 ;
@@ -137,10 +100,47 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:class skos:Concept ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
+            sh:path adms:status ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -479,6 +479,54 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:maxCount 1 ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:provenance ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:relation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path adms:versionNotes ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path adms:sample ;
             sh:severity sh:Violation
         ] ,
@@ -595,54 +643,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path dcterms:isVersionOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:issued ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:provenance ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:relation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:type ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path owl:versionInfo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path adms:versionNotes ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:identifier ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -767,6 +767,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path dcat:downloadURL ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class rdfs:Resource ;
+            sh:message "A `dcat:Distribution` _MUST_ have at least 1 `dcat:accessURL` predicate where the value node is `rdfs:Resource`." ;
+            sh:minCount 1 ;
+            sh:path dcat:accessURL ;
             sh:severity sh:Violation
         ] ,
         [

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -33,6 +33,60 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:class dcterms:Standard ;
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
@@ -86,60 +140,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dcterms:created ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:isPartOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -478,6 +478,56 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path prov:qualifiedAttribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:wasGeneratedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:duration ;
+            sh:maxCount 1 ;
+            sh:path dcat:temporalResolution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:path dcat:spatialResolutionInMeters ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:creator ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path dcat:distribution ;
             sh:severity sh:Violation
         ] ,
@@ -592,56 +642,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path dcterms:isReferencedBy ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path prov:qualifiedAttribution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path prov:wasGeneratedBy ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:duration ;
-            sh:maxCount 1 ;
-            sh:path dcat:temporalResolution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:decimal ;
-            sh:maxCount 1 ;
-            sh:path dcat:spatialResolutionInMeters ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:creator ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:IRI ;
-            sh:path dcatap:applicableLegislation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -1143,6 +1143,20 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass rdfs:Resource ;
+.
+
+:RightsStatement_Shape
+    a sh:NodeShape ;
+    rdfs:label "Rights Statement"@en ;
+    sh:property [
+            sh:maxCount 1 ;
+            sh:message "A `dcterms:RightsStatement` _MUST_ have exactly 1 `dcterms:title` predicate where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcterms:RightsStatement ;
 .
 
 :Standard_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -3,7 +3,9 @@ PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcatap: <http://data.europa.eu/r5r>
 PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX oa: <http://www.w3.org/ns/oa#>
 PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -27,43 +29,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:minCount 1 ;
             sh:node :DcatResource_Shape ;
             sh:path foaf:primaryTopic ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ,
         [
@@ -137,6 +102,43 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                     ]
                 ) ;
             sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -475,6 +477,51 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path adms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:sample ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:landingPage ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path foaf:page ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:qualifiedRelation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:isReferencedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:qualifiedAttribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:wasGeneratedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:duration ;
+            sh:maxCount 1 ;
+            sh:path dcat:temporalResolution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:path dcat:spatialResolutionInMeters ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path dcterms:creator ;
             sh:severity sh:Violation
         ] ,
@@ -594,51 +641,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:nodeKind sh:Literal ;
             sh:path adms:versionNotes ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:sample ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:landingPage ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path foaf:page ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:qualifiedRelation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:isReferencedBy ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path prov:qualifiedAttribution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path prov:wasGeneratedBy ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:duration ;
-            sh:maxCount 1 ;
-            sh:path dcat:temporalResolution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:decimal ;
-            sh:maxCount 1 ;
-            sh:path dcat:spatialResolutionInMeters ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -1016,6 +1018,52 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass schema:Person ;
+.
+
+:QualityAnnotation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Quality Annotation"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityAnnotation` _MAY_ have a maximum of 1 `oa:bodyvalue` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path oa:bodyvalue ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityAnnotation` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class rdfs:Resource ;
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityAnnotation` _MUST_ have exactly 1 `dcterms:source` predicate where the value node is `rdfs:Resource`." ;
+            sh:minCount 1 ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityAnnotation` _MUST_ have exactly 1 `oa:hasTarget` where the value node is an IRI." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path oa:hasTarget ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:hasValue dqv:qualityAssessment ;
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityAnnotation` _MUST_ have exactly 1 `oa:motivatedBy` where the value is `dqv:qualityAssessment`." ;
+            sh:minCount 1 ;
+            sh:path oa:motivatedBy ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dqv:QualityAnnotation ;
 .
 
 :Standard_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -222,7 +222,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:message "A `dcat:Catalog` _MAY_ have a `dcat:dataset predicate where the value node is a `dcat:Dataset`." ;
-            sh:nodeKind dcat:Dataset ;
+            sh:class dcat:Dataset ;
             sh:path dcat:dataset ;
             sh:severity sh:Violation
         ] ,

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -16,6 +16,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX spdx: <http://spdx.org/rdf/terms#>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
 PREFIX time: <http://www.w3.org/2006/time#>
@@ -34,11 +35,53 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:class skos:Concept ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
+            sh:path adms:status ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:minCount 1 ;
             sh:node :DateOrDateTimeDataType_Shape ;
             sh:path dcterms:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
             sh:severity sh:Violation
         ] ,
         [
@@ -97,50 +140,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                     ]
                 ) ;
             sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:class skos:Concept ;
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
-            sh:path adms:status ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -479,17 +478,313 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:funder` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:funder ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:editor` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:editor ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:producer` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:producer ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:publisher` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path dcterms:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:description` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcatap:applicableLegislation` where the value node is `sh:IRI`." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `dcterms:title` where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:identifier` where the value node is a literal with datatype `xsd:anyURI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dcat:Distribution ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcat:distribution` where the value node is `dcat:Distribution`." ;
+            sh:path dcat:distribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcat:keyword` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcat:keyword ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:spatial ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dcterms:PeriodOfTime ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:temporal` where the value node is `dcterms:PeriodOfTime`." ;
+            sh:path dcterms:temporal ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dqv:QualityAnnotation ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `dqv:hasQualityAnnotation` where the value node is `dqv:QualityAnnotation`." ;
+            sh:path dqv:hasQualityAnnotation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcat:theme` where the value is a literal or `skos:Concept`." ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal
+                    ]
+                    [
+                        sh:class skos:Concept
+                    ]
+                ) ;
+            sh:path dcat:theme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class skos:Concept ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcterms:accessRights` where the value is `skos:Concept`." ;
+            sh:path dcterms:accessRights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dqv:QualityMeasurement ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dqv:hasQualityMeasurement` where the value is `dqv:QualityMeasurement`." ;
+            sh:path dqv:hasQualityMeasurement ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `rdfs:comment` where the value is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path rdfs:comment ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class skos:Concept ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcterms:accrualPeriodicity` where the value is `skos:Concept`." ;
+            sh:path dcterms:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class tern:Method ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `sosa:usedProcedure` where the value is `tern:Method`." ;
+            sh:path sosa:usedProcedure ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcat:version` predicate where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcat:version ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class skos:Concept ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `adms:status` predicate where the value node is `skos:Concept`." ;
+            sh:minCount 1 ;
+            sh:path adms:status ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dcterms:LicenseDocumentation ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcterms:license` predicate where the value node is `dcterms:LicenseDocumentation`." ;
+            sh:path dcterms:license ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class tern:VerticalExtent ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `tern:verticalExtent` predicate where the value node is `tern:VerticalExtent`." ;
+            sh:path tern:verticalExtent ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `tern:resourceSpecificUsage` predicate where the value node is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:resourceSpecificUsage ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `tern:environmentDescription` predicate where the value node is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:environmentDescription ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `tern:supplementalInformation` predicate where the value node is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:supplementalInformation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class dcterms:RightsStatement ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:rights` predicate where the value node is `dcterms:RightsStatement`." ;
+            sh:path dcterms:rights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class geo:Geometry ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `geo:hasGeometry` predicate where the value node is `geo:Geometry`." ;
+            sh:path geo:hasGeometry ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `schema:abstract` predicate where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:abstract ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `schema:creditText` predicate where the value node is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path schema:creditText ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:bibliographCitation` predicate where the value node is a literal with datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:bibliographCitation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:subject` predicate where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:subject ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `skos:inScheme` predicate where the value node is `sh:IRI`." ;
+            sh:nodeKind sh:IRI ;
+            sh:path skos:inScheme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:hasVersion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:isVersionOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:path dcterms:issued ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
         ] ,
         [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcterms:language` predicate where the value node is `sh:IRI`." ;
+            sh:nodeKind sh:IRI ;
             sh:path dcterms:language ;
             sh:severity sh:Violation
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
             sh:path dcterms:modified ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
@@ -499,7 +794,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:class rdfs:Resource ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:relation` predicate where the value node is `rdfs:Resource`." ;
             sh:path dcterms:relation ;
             sh:severity sh:Violation
         ] ,
@@ -523,6 +819,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:datatype xsd:anyURI ;
+            sh:message "A `dcat:Dataset` _MAY_ have an `adms:identifier` predicate where the value node is a literal with datatype `xsd:anyURI`." ;
+            sh:nodeKind sh:Literal ;
             sh:path adms:identifier ;
             sh:severity sh:Violation
         ] ,
@@ -558,91 +857,43 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:datatype xsd:duration ;
             sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcat:temporalResolution` predicate where the value node is a literal with datatype `xsd:duration`." ;
+            sh:nodeKind sh:Literal ;
             sh:path dcat:temporalResolution ;
             sh:severity sh:Violation
         ] ,
         [
             sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MAY_ have a maximum of 1 `dcat:spatialResolutionInMeters` predicate where the value node is a literal with datatype `xsd:decimal`." ;
+            sh:nodeKind sh:Literal ;
             sh:path dcat:spatialResolutionInMeters ;
             sh:severity sh:Violation
         ] ,
         [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:creator` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
             sh:path dcterms:creator ;
             sh:severity sh:Violation
         ] ,
         [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:IRI ;
-            sh:path dcatap:applicableLegislation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:distribution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dcat:keyword ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:publisher ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:spatial ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:temporal ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:theme ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accessRights ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accrualPeriodicity ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:conformsTo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:hasVersion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:isVersionOf ;
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:collaborator` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:collaborator ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -32,10 +32,64 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:class dcterms:Standard ;
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
             sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ,
         [
@@ -85,60 +139,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:isPartOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -477,6 +477,54 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path dcterms:isVersionOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:provenance ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:relation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path adms:versionNotes ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path adms:identifier ;
             sh:severity sh:Violation
         ] ,
@@ -593,54 +641,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path dcterms:hasVersion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:isVersionOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:issued ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:provenance ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:relation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:type ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path owl:versionInfo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path adms:versionNotes ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -1064,6 +1064,60 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass dqv:QualityAnnotation ;
+.
+
+:Resource_Shape
+    a sh:NodeShape ;
+    rdfs:label "Resource"@en ;
+    sh:property
+        [
+            sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:message "A `rdfs:Resource`_MUST_ have exactly 1 `rdf:value` where the value node is a literal with datatype `xsd:anyURI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path rdf:value ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `rdfs:Resource` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `rdfs:Resource` _MUST_ have exactly 1 `dcterms:conformsTo` predicate where the value node is `sh:IRI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `rdfs:Resource` _MUST_ have exactly 1 `dcterms:type` predicate where the value node is `sh:IRI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `rdfs:Resource` _MUST_ have exactly 1 `dcterms:title` where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `rdfs:Resource` _MAY_ have a maximum of 1 `dcterms:format` where the value is a literal with datatype `xsd:string`." ;
+            sh:path dcterms:format ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass rdfs:Resource ;
 .
 
 :Standard_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -31,6 +31,60 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:minCount 1 ;
             sh:path dcterms:modified ;
@@ -83,60 +137,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
             sh:path <http://www.w3.org/2011/content#characterEncoding> ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dcterms:created ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:isPartOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -475,6 +475,51 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:hasVersion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:isVersionOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:provenance ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:relation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:path owl:versionInfo ;
@@ -594,51 +639,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:maxCount 1 ;
             sh:path dcterms:accrualPeriodicity ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:conformsTo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:hasVersion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:isVersionOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:issued ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:provenance ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:relation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:type ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -900,6 +900,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:property
         [
             sh:maxCount 1 ;
+            sh:message "A `dcterms:PeriodOfTime` _MAY_ have a maximum of 1 `dcat:endDate` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:nodeKind sh:Literal ;
             sh:path dcat:endDate ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape
@@ -916,6 +918,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcterms:PeriodOfTime` _MAY_ have a maximum of 1 `dcat:startDate` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:nodeKind sh:Literal ;
             sh:path dcat:startDate ;
             sh:severity sh:Violation ;
             sh:shape :DateOrDateTimeDataType_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -31,46 +31,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind schema:Person ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind schema:Organization ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:minCount 1 ;
             sh:path dcterms:modified ;
@@ -120,6 +80,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:source ;
@@ -137,6 +104,39 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind schema:Person ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind schema:Organization ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -318,7 +318,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:targetClass spdx:Checksum ;
 .
 
-:Concept
+:Concept_Shape
     a sh:NodeShape ;
     rdfs:label "Concept"@en ;
     sh:property
@@ -475,6 +475,50 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path adms:versionNotes ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:sample ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:landingPage ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path foaf:page ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:qualifiedRelation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:isReferencedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:qualifiedAttribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:wasGeneratedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:datatype xsd:duration ;
             sh:maxCount 1 ;
             sh:path dcat:temporalResolution ;
@@ -595,50 +639,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path dcterms:type ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path owl:versionInfo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path adms:versionNotes ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:sample ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:landingPage ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path foaf:page ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:qualifiedRelation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:isReferencedBy ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path prov:qualifiedAttribution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path prov:wasGeneratedBy ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -776,8 +776,34 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :LicenceDocument_Shape
     a sh:NodeShape ;
     rdfs:label "Licence Document"@en ;
-    sh:property [
+    sh:property
+        [
+            sh:message "A `dcterms:LicenseDocument` _MUST_ have at least 1 `dcterms:type` where the value node is an IRI." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
             sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcterms:LicenseDocument` _MUST_ have at least 1 `dcterms:title` where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcterms:LicenseDocument` _MAY_ have a `dcterms:description` predicate where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:message "A `dcterms:LicenseDocument` _MUST_ have exactly 1 `dcterms:identifier` where the value node is a literal with the datatype `xsd:anyURI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:identifier ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcterms:LicenseDocument ;

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -33,44 +33,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dcterms:created ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:isPartOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
             sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
             sh:minCount 1 ;
             sh:or (
@@ -123,6 +85,23 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:source ;
@@ -140,6 +119,27 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
             sh:nodeKind sh:IRI ;
             sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:isPartOf ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -478,6 +478,50 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path adms:versionNotes ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:sample ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:landingPage ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path foaf:page ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:qualifiedRelation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:isReferencedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path prov:qualifiedAttribution ;
             sh:severity sh:Violation
         ] ,
@@ -598,50 +642,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         [
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:path dcterms:relation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:type ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path owl:versionInfo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path adms:versionNotes ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:sample ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:landingPage ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path foaf:page ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:qualifiedRelation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:isReferencedBy ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -834,6 +834,34 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcterms:LicenseDocument ;
+.
+
+:Method_Shape
+    a sh:NodeShape ;
+    rdfs:label "Method"@en ;
+    sh:property
+        [
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `tern:Method` _MAY_ have a maximum of 1 `tern:scope` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:nodeKind sh:Literal ;
+            sh:path tern:scope ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class rdf:Seq ;
+            sh:maxCount 1 ;
+            sh:message "A `tern:Method` _MAY_ have a maximum of 1 `tern:instructions` predicate where the value node is `rdf:Seq`." ;
+            sh:path tern:instructions ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class rdfs:Resource ;
+            sh:message "A `tern:Method` _MAY_ have a `dcterms:source` where the value node is `rdfs:Resource`." ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass tern:Method ;
 .
 
 :Organization_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -30,44 +30,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:minCount 1 ;
-            sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dcterms:created ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:isPartOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
             sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
             sh:minCount 1 ;
             sh:or (
@@ -119,6 +81,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:class skos:Concept ;
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
@@ -137,6 +106,37 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
             sh:path <http://www.w3.org/2011/content#characterEncoding> ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:minCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -475,6 +475,72 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
+            sh:path dcterms:creator ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:distribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dcat:keyword ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:spatial ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:temporal ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:theme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accessRights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:path dcterms:conformsTo ;
             sh:severity sh:Violation
         ] ,
@@ -573,72 +639,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:datatype xsd:decimal ;
             sh:maxCount 1 ;
             sh:path dcat:spatialResolutionInMeters ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:creator ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:IRI ;
-            sh:path dcatap:applicableLegislation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:distribution ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path dcat:keyword ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:publisher ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:spatial ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:temporal ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcat:theme ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accessRights ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accrualPeriodicity ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -1016,6 +1016,42 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass schema:Person ;
+.
+
+:Standard_Shape
+    a sh:NodeShape ;
+    rdfs:label "Standard"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcterms:Standard` _MAY_ have a maximum of 1 `dcterms:title` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcterms:Standard` _MAY_ have a maximum of 1 `owl:versionInfo` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcterms:Standard` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcterms:Standard` _MUST_ have exactly 1 `dcterms:identifier` where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcterms:Standard ;
 .
 
 :DcatResource_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -6,6 +6,7 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX dqv: <http://www.w3.org/ns/dqv#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geodcat: <http://data.europa.eu/930/>
 PREFIX oa: <http://www.w3.org/ns/oa#>
 PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -30,44 +31,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:minCount 1 ;
             sh:node :DcatResource_Shape ;
             sh:path foaf:primaryTopic ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
-            sh:node :DateOrDateTimeDataType_Shape ;
-            sh:path dcterms:issued ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:nodeKind sh:Literal ;
-                        sh:severity sh:Violation
-                    ]
-                    [
-                        sh:nodeKind sh:IRI ;
-                        sh:severity sh:Violation
-                    ]
-                ) ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:source ;
             sh:severity sh:Violation
         ] ,
         [
@@ -122,6 +85,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
             sh:class dcterms:Standard ;
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
@@ -140,6 +110,37 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
             sh:nodeKind sh:Literal ;
             sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:nodeKind sh:Literal ;
+                        sh:severity sh:Violation
+                    ]
+                    [
+                        sh:nodeKind sh:IRI ;
+                        sh:severity sh:Violation
+                    ]
+                ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:source ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -478,76 +479,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:label "Dataset"@en ;
     sh:property
         [
-            sh:maxCount 1 ;
-            sh:path dcterms:accessRights ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:accrualPeriodicity ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:conformsTo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:hasVersion ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:isVersionOf ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:issued ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:path dcterms:modified ;
-            sh:severity sh:Violation ;
-            sh:shape :DateOrDateTimeDataType_Shape
-        ] ,
-        [
-            sh:path dcterms:provenance ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:path dcterms:relation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path dcterms:type ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path owl:versionInfo ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:nodeKind sh:Literal ;
-            sh:path adms:versionNotes ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:path adms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
             sh:path adms:sample ;
             sh:severity sh:Violation
         ] ,
@@ -642,6 +573,76 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ,
         [
             sh:path dcat:theme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accessRights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:hasVersion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:isVersionOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:issued ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcterms:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dcterms:provenance ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcterms:relation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcterms:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path adms:versionNotes ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:identifier ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;
@@ -1117,6 +1118,51 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ;
     sh:targetClass dqv:QualityAnnotation ;
+.
+
+:QualityMeasurement_Shape
+    a sh:NodeShape ;
+    rdfs:label "Quality Measurement"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityMeasurement` _MUST_ have exactly 1 `dqv:isMeasurementOf` where the value is `geodcat:spatialResolutionAsAngularDistance`, `geodcat:spatialResolutionAsDistance`, `geodcat:spatialResolutionAsScale`, or `geodcat:spatialResolutionAsVerticalDistance`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:hasValue geodcat:spatialResolutionAsAngularDistance
+                    ]
+                    [
+                        sh:hasValue geodcat:spatialResolutionAsDistance
+                    ]
+                    [
+                        sh:hasValue geodcat:spatialResolutionAsScale
+                    ]
+                    [
+                        sh:hasValue geodcat:spatialResolutionAsVerticalDistance
+                    ]
+                ) ;
+            sh:path dqv:isMeasurementOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityMeasurement` _MUST_ have exactly 1 `dqv:value` predicate where the value node is a literal with datatype `xsd:decimal`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dqv:value ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dqv:QualityMeasurement` _MUST_ have exactly 1 `tern:unit` predicate where the value node is an IRI." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path tern:unit ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dqv:QualityMeasurement ;
 .
 
 :Resource_Shape

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -1,0 +1,997 @@
+PREFIX : <https://w3id.org/tern/shapes/dcat/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcatap: <http://data.europa.eu/r5r>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX lcon: <http://www.w3.org/ns/locn#>
+PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX spdx: <http://spdx.org/rdf/terms#>
+PREFIX time: <http://www.w3.org/2006/time#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:Person_Shape
+    a sh:NodeShape ;
+    rdfs:label "Person"@en ;
+    sh:property
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Person` _MUST_ have at least 1 `schema:name` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:name ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:message "A `schema:Person` _MUST_ have at least 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:or (
+                [
+                    sh:nodeKind sh:Literal ;
+                    sh:severity sh:Violation
+                ]
+                [
+                    sh:nodeKind sh:IRI ;
+                    sh:severity sh:Violation
+                ]
+            ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:message "A `schema:Person` _MAY_ have a `schema:affiliation` where the value node is an IRI." ;
+            sh:path schema:affiliation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Person` _MAY_ have a `schema:email` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:email ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Person` _MAY_ have a `schema:telephone` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:telephone ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressCountry` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:addressCountry ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressLocality` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:addressLocality ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:addressRegion` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:addressRegion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:postalCode` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:postalCode ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Person` _MAY_ have a maximum of 1 `schema:streetAddress` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:streetAddress ;
+            sh:severity sh:Violation
+        ] ,
+ ;
+    sh:targetClass schema:Person ;
+.
+
+:Organization_Shape
+    a sh:NodeShape ;
+    rdfs:label "Organization"@en ;
+    sh:property
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Organization` _MUST_ have at least 1 `schema:name` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:name ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:message "A `schema:Organization` _MUST_ have at least 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:or (
+                [
+                    sh:nodeKind sh:Literal ;
+                    sh:severity sh:Violation
+                ]
+                [
+                    sh:nodeKind sh:IRI ;
+                    sh:severity sh:Violation
+                ]
+            ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Organization` _MAY_ have a `schema:email` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:email ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:message "A `schema:Organization` _MAY_ have a `schema:telephone` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:telephone ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressCountry` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:addressCountry ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressLocality` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:addressLocality ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:addressRegion` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:addressRegion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:postalCode` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:postalCode ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "A `schema:Organization` _MAY_ have a maximum of 1 `schema:streetAddress` where the value node is a literal with the datatype `xsd:string`." ;
+            sh:path schema:streetAddress ;
+            sh:severity sh:Violation
+        ] ,
+ ;
+    sh:targetClass schema:Organization ;
+.
+
+:CatalogRecord_Shape
+    a sh:NodeShape ;
+    rdfs:label "Catalog Record"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `foaf:primaryTopic` predicate where the value node is an individual with the type `dcat:Catalog`, or `dcat:Dataset`, or `dcat:DataService`." ;
+            sh:node :DcatResource_Shape ;
+            sh:path foaf:primaryTopic ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:path dct:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:class dcterms:Standard ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:conformsTo` predicate where the value node is an IRI of an individual with the type `dcterms:Standard`." ;
+            sh:path dct:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dct:issued ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
+            sh:class skos:Concept ;
+            sh:path adms:status ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
+            sh:path dct:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dct:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dct:created ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:isPartOf` predicate where the value node is an IRI." ;
+            sh:path dct:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 <http://www.w3.org/2011/content#characterEncoding> predicate where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/2011/content#characterEncoding> ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal." ;
+            sh:or (
+                [
+                    sh:nodeKind sh:Literal ;
+                    sh:severity sh:Violation
+                ]
+                [
+                    sh:nodeKind sh:IRI ;
+                    sh:severity sh:Violation
+                ]
+            ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                [
+                    sh:nodeKind schema:Person ;
+                    sh:severity sh:Violation
+                ]
+                [
+                    sh:nodeKind schema:Organization ;
+                    sh:severity sh:Violation
+                ]
+            ) ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a `dcterms:title` predicate where the value node is a literal value." ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:description` where the value node is a literal value." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:description ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcat:CatalogRecord ;
+.
+
+:Catalog_Shape
+    a sh:NodeShape ;
+    rdfs:label "Catalog"@en ;
+    sh:property
+        [
+            sh:path dct:language ;
+            sh:nodeKind sh:IRI ;
+            sh:message "A `dcat:Catalog` _MAY_ have a `dcterms:language` predicate where the value node is an IRI." ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:message "A `dcat:Catalog` _MAY_ have a `dcatap:applicableLegislation` predicate where the value node is an IRI." ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Catalog` _MAY_ have a maximum of 1 `dcterms:license`." ;
+            sh:path dct:license ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Catalog` _MAY_ have a maximum of 1 `dcterms:issued` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dct:issued ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:spatial ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:hasPart ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:isPartOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:message "A `dcat:Catalog` _MUST_ have exactly 1 `dcterms:modified` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
+            sh:path dct:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:rights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:record ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:themeTaxonomy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:service ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:catalog ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:creator ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind dcat:Dataset ;
+            sh:message "A `dcat:Catalog` _MAY_ have a `dcat:dataset predicate where the value node is a `dcat:Dataset`." ;
+            sh:path dcat:dataset ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:message "A `dcat:Catalog` _MUST_ have at least 1 `dcterms:description` where the value node is literal." ;
+            sh:path dct:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:message "A `dcat:Catalog` _MUST_ have exactly 1 `dcterms:publisher`." ;
+            sh:path dct:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:message "A `dcat:Catalog` _MUST_ have at least 1 `dcterms:title` where the value node is literal." ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Catalog` _MUST_ have exactly 1 `dcterms:identifier` where the value node is an IRI or literal with the datatype `xsd:anyURI`." ;
+            sh:or (
+                [
+                    sh:nodeKind sh:Literal ;
+                    sh:datatype xsd:anyURI ;
+                    sh:severity sh:Violation
+                ]
+                [
+                    sh:nodeKind sh:IRI ;
+                    sh:severity sh:Violation
+                ]
+            ) ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:datatype xsd:anyURI ;
+            sh:nodeKind sh:Literal ;
+            sh:message "A `dcat:Catalog` _MAY_ have a maximum of 1 `foaf:homepage` where the value node is a literal with the datatype `xsd:anyURI`." ;
+            sh:path foaf:homepage ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcat:Catalog ;
+.
+
+:CategoryScheme_Shape
+    a sh:NodeShape ;
+    rdfs:label "Category Scheme"@en ;
+    sh:property [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass skos:ConceptScheme ;
+.
+
+:Category_Shape
+    a sh:NodeShape ;
+    rdfs:label "Category"@en ;
+    sh:property [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path skos:prefLabel ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass skos:Concept ;
+.
+
+:Checksum_Shape
+    a sh:NodeShape ;
+    rdfs:label "Checksum"@en ;
+    sh:property
+        [
+            sh:hasValue spdx:checksumAlgorithm_sha1 ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path spdx:algorithm ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:hexBinary ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path spdx:checksumValue ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass spdx:Checksum ;
+.
+
+:DataService_Shape
+    a sh:NodeShape ;
+    rdfs:label "Data Service"@en ;
+    sh:property
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcat:endpointURL ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:servesDataset ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dct:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcat:endpointDescription ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:license ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:accessRights ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcat:DataService ;
+.
+
+:DatasetSeries_Shape
+    a sh:NodeShape ;
+    rdfs:label "Dataset Series"@en ;
+    sh:property
+        [
+            sh:inversePath dcat:inSeries ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:severity sh:Warning
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dct:spatial ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dct:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:issued ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:modified ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dct:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dct:temporal ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcat:DatasetSeries ;
+.
+
+:Dataset_Shape
+    a sh:NodeShape ;
+    rdfs:label "Dataset"@en ;
+    sh:property
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dct:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:contactPoint ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:distribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dcat:keyword ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:spatial ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:temporal ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:theme ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:accessRights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:accrualPeriodicity ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:hasVersion ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:isVersionOf ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:issued ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dct:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:modified ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:path dct:provenance ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dct:relation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:type ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path owl:versionInfo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path adms:versionNotes ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path adms:sample ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:landingPage ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path foaf:page ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:qualifiedRelation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dct:isReferencedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:qualifiedAttribution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path prov:wasGeneratedBy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:duration ;
+            sh:maxCount 1 ;
+            sh:path dcat:temporalResolution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:path dcat:spatialResolutionInMeters ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:creator ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcat:Dataset ;
+.
+
+:Distribution_Shape
+    a sh:NodeShape ;
+    rdfs:label "Distribution"@en ;
+    sh:property
+        [
+            sh:path foaf:page ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path odrl:hasPolicy ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dcat:accessService ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcat:compressFormat ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcat:packageFormat ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:duration ;
+            sh:maxCount 1 ;
+            sh:path dcat:temporalResolution ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:path dcat:spatialResolutionInMeters ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcat:accessURL ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dct:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcatap:availability ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:format ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:license ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:conformsTo ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dct:issued ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:path dct:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:node :DateOrDateTimeDataType_Shape ;
+            sh:path dct:modified ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dct:rights ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:Literal ;
+            sh:path dct:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path spdx:checksum ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path adms:status ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:decimal ;
+            sh:maxCount 1 ;
+            sh:path dcat:byteSize ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path dcat:downloadURL ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcat:mediaType ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dcat:Distribution ;
+.
+
+:LicenceDocument_Shape
+    a sh:NodeShape ;
+    rdfs:label "Licence Document"@en ;
+    sh:property [
+            sh:path dct:type ;
+            sh:severity sh:Violation
+        ] ;
+    sh:targetClass dct:LicenseDocument ;
+.
+
+:PeriodOfTime_Shape
+    a sh:NodeShape ;
+    rdfs:label "PeriodOfTime"@en ;
+    sh:property
+        [
+            sh:maxCount 1 ;
+            sh:path dcat:endDate ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path time:hasBeginning ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path time:hasEnd ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:path dcat:startDate ;
+            sh:severity sh:Violation ;
+            sh:shape :DateOrDateTimeDataType_Shape
+        ] ;
+    sh:targetClass dct:PeriodOfTime ;
+.
+
+:DcatResource_Shape
+    a sh:NodeShape ;
+    rdfs:label "dcat:Resource" ;
+    rdfs:comment "the union of Catalog, Dataset and DataService" ;
+    sh:message "The node is either a Catalog, Dataset or a DataService" ;
+    sh:or (
+            [
+                sh:class dcat:Catalog
+            ]
+            [
+                sh:class dcat:Dataset
+            ]
+            [
+                sh:class dcat:DataService
+            ]
+        ) ;
+.
+
+:DateOrDateTimeDataType_Shape
+    a sh:NodeShape ;
+    rdfs:label "Date time date disjunction" ;
+    rdfs:comment "Date time date disjunction shape checks that a datatype property receives a temporal value: date, dateTime, gYear or gYearMonth literal" ;
+    sh:message "The values must be data typed as either xsd:date, xsd:dateTime, xsd:gYear or xsd:gYearMonth" ;
+    sh:or (
+            [
+                sh:datatype xsd:date
+            ]
+            [
+                sh:datatype xsd:dateTime
+            ]
+            [
+                sh:datatype xsd:gYear
+            ]
+            [
+                sh:datatype xsd:gYearMonth
+            ]
+        ) ;
+.
+

--- a/docs/dcat-shapes.ttl
+++ b/docs/dcat-shapes.ttl
@@ -35,41 +35,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:class skos:Concept ;
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
-            sh:path adms:status ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:source ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcterms:language ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:class schema:Person
-                    ]
-                    [
-                        sh:class schema:Organization
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
-        [
             sh:maxCount 1 ;
             sh:message "A `dcat:CatalogRecord` _MUST_ have exactly 1 `dcterms:created` predicate where the value node is a literal with the datatype `xsd:date`, `xsd:dateTime`, `xsd:gYear` or `xsd:gYearMonth`." ;
             sh:minCount 1 ;
@@ -140,6 +105,41 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                     ]
                 ) ;
             sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:class skos:Concept ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `adms:status` predicate where the value node is an IRI of an individual with the type `skos:Concept`." ;
+            sh:path adms:status ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:source` predicate where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:source ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:CatalogRecord` _MAY_ have a maximum of 1 `dcterms:language` where the value node is an IRI." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcterms:language ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:CatalogRecord` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:CatalogRecord ;
@@ -221,8 +221,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             sh:severity sh:Violation
         ] ,
         [
-            sh:message "A `dcat:Catalog` _MAY_ have a `dcat:dataset predicate where the value node is a `dcat:Dataset`." ;
             sh:class dcat:Dataset ;
+            sh:message "A `dcat:Catalog` _MAY_ have a `dcat:dataset predicate where the value node is a `dcat:Dataset`." ;
             sh:path dcat:dataset ;
             sh:severity sh:Violation
         ] ,
@@ -477,102 +477,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a sh:NodeShape ;
     rdfs:label "Dataset"@en ;
     sh:property
-        [
-            sh:message "A `dcat:Dataset` _MAY_ have a `tern:funder` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:or (
-                    [
-                        sh:class schema:Person
-                    ]
-                    [
-                        sh:class schema:Organization
-                    ]
-                ) ;
-            sh:path tern:funder ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:Dataset` _MAY_ have a `tern:editor` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:or (
-                    [
-                        sh:class schema:Person
-                    ]
-                    [
-                        sh:class schema:Organization
-                    ]
-                ) ;
-            sh:path tern:editor ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:Dataset` _MAY_ have a `tern:producer` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:or (
-                    [
-                        sh:class schema:Person
-                    ]
-                    [
-                        sh:class schema:Organization
-                    ]
-                ) ;
-            sh:path tern:producer ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:maxCount 1 ;
-            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:publisher` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:class schema:Person
-                    ]
-                    [
-                        sh:class schema:Organization
-                    ]
-                ) ;
-            sh:path dcterms:publisher ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:description` where the value node is a literal." ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:description ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:Dataset` _MAY_ have a `dcatap:applicableLegislation` where the value node is `sh:IRI`." ;
-            sh:nodeKind sh:IRI ;
-            sh:path dcatap:applicableLegislation ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `dcterms:title` where the value node is a literal." ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:title ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:datatype xsd:anyURI ;
-            sh:maxCount 1 ;
-            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:identifier` where the value node is a literal with datatype `xsd:anyURI`." ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:path dcterms:identifier ;
-            sh:severity sh:Violation
-        ] ,
-        [
-            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
-            sh:minCount 1 ;
-            sh:or (
-                    [
-                        sh:class schema:Person
-                    ]
-                    [
-                        sh:class schema:Organization
-                    ]
-                ) ;
-            sh:path dcat:contactPoint ;
-            sh:severity sh:Violation
-        ] ,
         [
             sh:class dcat:Distribution ;
             sh:message "A `dcat:Dataset` _MAY_ have a `dcat:distribution` where the value node is `dcat:Distribution`." ;
@@ -894,6 +798,102 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                     ]
                 ) ;
             sh:path tern:collaborator ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:funder` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:funder ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:editor` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:editor ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `tern:producer` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path tern:producer ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:publisher` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path dcterms:publisher ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcterms:description` where the value node is a literal." ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:description ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MAY_ have a `dcatap:applicableLegislation` where the value node is `sh:IRI`." ;
+            sh:nodeKind sh:IRI ;
+            sh:path dcatap:applicableLegislation ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `dcterms:title` where the value node is a literal." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:title ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:message "A `dcat:Dataset` _MUST_ have exactly 1 `dcterms:identifier` where the value node is a literal with datatype `xsd:anyURI`." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path dcterms:identifier ;
+            sh:severity sh:Violation
+        ] ,
+        [
+            sh:message "A `dcat:Dataset` _MUST_ have at least 1 `dcat:contactPoint` where the value node is a `schema:Person` or `schema:Organization`." ;
+            sh:minCount 1 ;
+            sh:or (
+                    [
+                        sh:class schema:Person
+                    ]
+                    [
+                        sh:class schema:Organization
+                    ]
+                ) ;
+            sh:path dcat:contactPoint ;
             sh:severity sh:Violation
         ] ;
     sh:targetClass dcat:Dataset ;


### PR DESCRIPTION
This PR adds SHACL shapes for all classes and properties used in DCAT metadata.